### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Product overview
+
+TryOnYou is a luxury fashion virtual try-on SPA (React + Vite + Tailwind) with a Python FastAPI backend. It is deployed on Vercel (frontend static + Python serverless functions). Patent PCT/EP2025/067317.
+
+### Services
+
+| Service | Command | Port | Notes |
+|---|---|---|---|
+| **Frontend (Vite)** | `npm run dev` | 5173 | Proxies `/api` requests to backend on port 8000 |
+| **Backend (FastAPI)** | `uvicorn backend.omega_core:app --reload --port 8000` | 8000 | Health: `GET /health`, Snap: `POST /api/snap` |
+
+### Running the dev environment
+
+1. Start backend: `uvicorn backend.omega_core:app --reload --port 8000`
+2. Start frontend: `npm run dev`
+3. Open `http://localhost:5173/?postal=75009` (the `postal` param activates the PAU pilot mode)
+
+### Build
+
+- `npm run build` — runs `prebuild` (validates `firebase-applet-config.json` projectId) then Vite production build.
+
+### TypeScript
+
+- `npx tsc --noEmit` reports errors about `import.meta.env` because there is no `src/vite-env.d.ts` referencing `vite/client` types. These errors do **not** block the Vite build or dev server — Vite handles `import.meta.env` natively. This is a known gap in the repo.
+
+### Lint
+
+- No ESLint config is present in the repo. TypeScript strict mode (`tsconfig.json`) is the primary static check.
+
+### Tests
+
+- No automated test framework is configured. Testing is manual via browser and API calls.
+
+### Environment variables
+
+- See `.env.example` for the full list. No `.env` file is committed.
+- Firebase, Stripe, Make.com, and other external service keys are optional for local dev — the app runs without them (features that depend on those keys simply won't work).
+- The `prebuild` step (`scripts/assert-firebase-applet.mjs`) requires `firebase-applet-config.json` with `projectId` set to `gen-lang-client-0066102635`. This file is committed and does not need changes.
+
+### Python path
+
+- `uvicorn` and `fastapi` install to `~/.local/bin`. Ensure this is on `PATH`:
+  ```
+  export PATH="$HOME/.local/bin:$PATH"
+  ```
+
+### Crontab note
+
+- The workspace rules mention `0 9 * * * /usr/bin/python3 /ruta/a/tu/daily_manager.py` — this is a production cron reference, not relevant for local dev setup.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific development environment instructions so future agents can quickly set up and run the project.

### What's included

- Service overview table (Vite frontend on 5173, FastAPI backend on 8000)
- Step-by-step dev environment startup instructions
- Build, TypeScript, and lint notes (including the known `import.meta.env` type gap)
- Environment variable guidance (referencing `.env.example`)
- Python PATH caveat for `~/.local/bin`

### Dev environment verification

All services were started and tested:

| Check | Result |
|---|---|
| `npm install` | 176 packages, 0 vulnerabilities |
| `npm run build` | Vite build succeeded (6 chunks) |
| `npx tsc --noEmit` | Known `import.meta.env` errors only (no code bug) |
| Backend `GET /health` | `{"ok": true, "version": "10.5-Soberania"}` |
| Backend `POST /api/snap` | `{"status": "SUCCESS", ...}` |
| Vite proxy `/api/snap` | Proxied correctly to backend |
| Frontend loads at `localhost:5173/?postal=75009` | Full PAU pilot UI rendered |

### Demo

[tryonyou_dev_hello_world_demo.mp4](https://cursor.com/agents/bc-8ad60f76-b72b-4c6c-8bfd-fb21dbda56d1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftryonyou_dev_hello_world_demo.mp4)

Frontend loaded with PAU pilot mode, entered test email, clicked "Pruébatela YA" button.

[Frontend loaded](https://cursor.com/agents/bc-8ad60f76-b72b-4c6c-8bfd-fb21dbda56d1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_frontend_loaded.webp)
[API response alert](https://cursor.com/agents/bc-8ad60f76-b72b-4c6c-8bfd-fb21dbda56d1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_alert_response.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ad60f76-b72b-4c6c-8bfd-fb21dbda56d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ad60f76-b72b-4c6c-8bfd-fb21dbda56d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

