### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+TryOnYou is a React + Vite + Tailwind CSS virtual try-on fashion-tech app (TypeScript frontend, Python FastAPI backend). See `README.md` and `.cursor/rules/` for project lore and protocol context.
+
+### Running services
+
+| Service | Command | Port | Notes |
+|---|---|---|---|
+| Frontend (Vite dev) | `npm run dev` | 5173 | Proxies `/api` to backend on 8000 |
+| Backend (FastAPI) | `uvicorn backend.omega_core:app --reload --port 8000` | 8000 | Local demo API |
+
+Start the backend **before** the frontend so the API proxy works immediately.
+
+### Build
+
+`npm run build` — runs the `prebuild` assertion (`scripts/assert-firebase-applet.mjs` checks `firebase-applet-config.json` projectId) then Vite production build to `dist/`.
+
+### TypeScript
+
+`npx tsc --noEmit` reports `import.meta.env` errors because the repo is missing `src/vite-env.d.ts`. This is a pre-existing issue; Vite build and dev server handle these types internally and work fine.
+
+### Lint / tests
+
+No ESLint config or test framework (Jest/Vitest) is configured in this repo. The primary verification commands are:
+- `npx tsc --noEmit` (TypeScript type-check; has known `import.meta.env` errors)
+- `npm run build` (Vite production build)
+
+### Environment variables
+
+Copy `.env.example` to `.env`. Most `VITE_*` vars are optional for local dev. Firebase features (auth, analytics, App Check) require `VITE_FIREBASE_API_KEY` + related keys from the Firebase console. Without them the app loads fine but Firebase-dependent features are inactive.
+
+### Python dependencies
+
+Multiple `requirements.txt` files exist:
+- `/requirements.txt` — Flask API (Vercel serverless functions)
+- `/backend/requirements.txt` — FastAPI local backend (required for dev)
+- `/voice_agent/requirements.txt` and `/tryonme-voice-agent/requirements.txt` — optional voice agents


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents.

### What's included

- Service startup commands (Vite frontend on 5173, FastAPI backend on 8000)
- Build and TypeScript check notes (known pre-existing `import.meta.env` errors)
- Environment variable setup reference
- Python dependency file locations

### Verification

The full dev environment was set up and verified:

- `npm install` — 176 packages, 0 vulnerabilities
- `pip install -r requirements.txt -r backend/requirements.txt` — all Python deps installed
- `npm run build` — Vite production build succeeds
- FastAPI backend health check returns `{"ok":true,"version":"10.5-Soberania"}`
- Vite dev server serves the app at `http://localhost:5173`
- API proxy `/api/snap` works end-to-end through Vite → FastAPI

### Demo

[tryonyou_app_demo_interaction.mp4](https://cursor.com/agents/bc-2a7d3f21-399a-4299-a74f-a11cdf3ba711/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftryonyou_app_demo_interaction.mp4)

App loaded and interactive — email input, try-on button, PAU snap all functional.

[TryOnYou homepage loaded at localhost:5173](https://cursor.com/agents/bc-2a7d3f21-399a-4299-a74f-a11cdf3ba711/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_loaded_homepage.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a7d3f21-399a-4299-a74f-a11cdf3ba711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a7d3f21-399a-4299-a74f-a11cdf3ba711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

