### PR TITLE
feat: auditoría de impacto matinal + monitor de liquidez SEPA (V10)

### DIFF
--- a/auditoria_impacto_matinal.py
+++ b/auditoria_impacto_matinal.py
@@ -1,7 +1,12 @@
 """
 Auditoría de impacto matinal V10 — verificación de clearing bancario (Lafayette / LVMH).
 
-  python3 auditoria_impacto_matinal.py
+Incluye dos flujos complementarios:
+  - check_bank_impact()          → auditoría de ingresos esperados (resumen diario).
+  - check_immediate_liquidity()  → monitor de liquidez SEPA en tiempo real (minuto a minuto).
+
+  python3 auditoria_impacto_matinal.py             # auditoría completa (ambos flujos)
+  python3 auditoria_impacto_matinal.py --liquidez   # solo monitor de liquidez SEPA
 
   # Envío al centinela Telegram:
   export AUDIT_SEND_TELEGRAM=1
@@ -14,6 +19,7 @@ Patente: PCT/EP2025/067317
 
 from __future__ import annotations
 
+import argparse
 import os
 import sys
 from datetime import datetime
@@ -69,6 +75,67 @@ def check_bank_impact(*, now: datetime | None = None) -> dict:
         "ingresos": INGRESOS_ESPERADOS,
         "timestamp": ahora.isoformat(),
     }
+
+
+SEPA_SWEEP_MARGIN_MINUTES = 15
+
+
+def check_immediate_liquidity(*, now: datetime | None = None) -> dict:
+    """Real-time SEPA liquidity monitor relative to the 09:00 clearing window.
+
+    Parameters
+    ----------
+    now : datetime, optional
+        Override for the current timestamp (useful for testing).
+
+    Returns
+    -------
+    dict with keys:
+        status          – human-readable status line
+        sweep_started   – True once the SEPA sweep hour has passed
+        minutes_left    – minutes until sweep (0 when sweep_started is True)
+        timestamp       – ISO-formatted monitor time
+    """
+    ahora = now or datetime.now()
+    target_time = ahora.replace(hour=CLEARING_HOUR, minute=0, second=0, microsecond=0)
+
+    if ahora < target_time:
+        faltan = int((target_time - ahora).total_seconds() / 60)
+        estado = (
+            f"ESTADO: EN TRÁNSITO. Faltan {faltan} minutos "
+            "para el barrido bancario SEPA."
+        )
+        return {
+            "status": estado,
+            "sweep_started": False,
+            "minutes_left": faltan,
+            "timestamp": ahora.isoformat(),
+        }
+
+    estado = (
+        "ESTADO: BARRIDO INICIADO. "
+        f"Revisa tu banca online en los próximos {SEPA_SWEEP_MARGIN_MINUTES} minutos."
+    )
+    return {
+        "status": estado,
+        "sweep_started": True,
+        "minutes_left": 0,
+        "timestamp": ahora.isoformat(),
+    }
+
+
+def formato_liquidez(result: dict) -> str:
+    """Pretty-print the liquidity monitor result for terminal / Telegram."""
+    lineas = [
+        f"--- [MONITOR DE LIQUIDEZ: {result['timestamp']}] ---",
+        "",
+        result["status"],
+        "",
+        f"SIREN: {SIREN_REF}",
+        "Patente: PCT/EP2025/067317",
+        "Bajo Protocolo de Soberanía V10 - Founder: Rubén",
+    ]
+    return "\n".join(lineas)
 
 
 def formato_consola(result: dict) -> str:
@@ -127,9 +194,29 @@ def _enviar_telegram(texto: str) -> bool:
     return False
 
 
-def main() -> int:
-    result = check_bank_impact()
-    texto = formato_consola(result)
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Auditoría de impacto matinal V10 — clearing bancario Lafayette/LVMH.",
+    )
+    parser.add_argument(
+        "--liquidez",
+        action="store_true",
+        help="Solo muestra el monitor de liquidez SEPA (sin auditoría completa).",
+    )
+    args = parser.parse_args(argv)
+
+    bloques: list[str] = []
+
+    if args.liquidez:
+        liq = check_immediate_liquidity()
+        bloques.append(formato_liquidez(liq))
+    else:
+        result = check_bank_impact()
+        bloques.append(formato_consola(result))
+        liq = check_immediate_liquidity()
+        bloques.append(formato_liquidez(liq))
+
+    texto = "\n\n".join(bloques)
     print(texto)
 
     if os.environ.get("AUDIT_SEND_TELEGRAM", "").strip() in ("1", "true", "yes"):

--- a/auditoria_impacto_matinal.py
+++ b/auditoria_impacto_matinal.py
@@ -1,0 +1,142 @@
+"""
+Auditoría de impacto matinal V10 — verificación de clearing bancario (Lafayette / LVMH).
+
+  python3 auditoria_impacto_matinal.py
+
+  # Envío al centinela Telegram:
+  export AUDIT_SEND_TELEGRAM=1
+  export TELEGRAM_BOT_TOKEN='…'   # o TELEGRAM_TOKEN
+  export TELEGRAM_CHAT_ID='…'
+  python3 auditoria_impacto_matinal.py
+
+Patente: PCT/EP2025/067317
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime
+from typing import Dict, List
+
+SIREN_REF = "943 610 196"
+CLEARING_HOUR = 9
+OBJETIVO_TOTAL = 405_680.00
+
+INGRESOS_ESPERADOS: List[Dict[str, object]] = [
+    {"origen": "Lafayette", "importe": 27_500.00},
+    {"origen": "LVMH", "importe": 22_500.00},
+]
+
+
+def check_bank_impact(*, now: datetime | None = None) -> dict:
+    """Return a structured audit result for the morning bank clearing window.
+
+    Parameters
+    ----------
+    now : datetime, optional
+        Override for the current timestamp (useful for testing).
+
+    Returns
+    -------
+    dict with keys:
+        status     – human-readable status line
+        clearing   – True if the clearing window has passed
+        objetivo   – target total in EUR
+        ingresos   – list of expected line items
+        timestamp  – ISO-formatted audit time
+    """
+    ahora = now or datetime.now()
+
+    clearing_done = ahora.hour >= CLEARING_HOUR
+
+    if clearing_done:
+        estado = (
+            "ESTADO: Revisa tu App Bancaria AHORA. "
+            "El clearing ha finalizado."
+        )
+    else:
+        minutos_restantes = (CLEARING_HOUR - ahora.hour - 1) * 60 + (60 - ahora.minute)
+        estado = (
+            f"ESTADO: Faltan {minutos_restantes} minutos "
+            f"para el barrido bancario de las {CLEARING_HOUR:02d}:00."
+        )
+
+    return {
+        "status": estado,
+        "clearing": clearing_done,
+        "objetivo": OBJETIVO_TOTAL,
+        "ingresos": INGRESOS_ESPERADOS,
+        "timestamp": ahora.isoformat(),
+    }
+
+
+def formato_consola(result: dict) -> str:
+    """Pretty-print the audit result for terminal / Telegram."""
+    lineas = [
+        "--- [AUDITORÍA DE IMPACTO MATINAL] ---",
+        f"🕐 Timestamp: {result['timestamp']}",
+        f"🎯 Objetivo total: {result['objetivo']:,.2f} €",
+        "",
+    ]
+    for ing in result["ingresos"]:
+        lineas.append(f"  🔎 Buscando ingreso de: {ing['importe']:,.2f} € ({ing['origen']})")
+
+    lineas += [
+        "",
+        f"📊 Clearing (>= {CLEARING_HOUR:02d}:00): {'SÍ' if result['clearing'] else 'NO'}",
+        result["status"],
+        "",
+        f"SIREN: {SIREN_REF}",
+        "Patente: PCT/EP2025/067317",
+        "Bajo Protocolo de Soberanía V10 - Founder: Rubén",
+    ]
+    return "\n".join(lineas)
+
+
+def _enviar_telegram(texto: str) -> bool:
+    token = (
+        os.environ.get("TELEGRAM_BOT_TOKEN", "").strip()
+        or os.environ.get("TELEGRAM_TOKEN", "").strip()
+    )
+    chat = os.environ.get("TELEGRAM_CHAT_ID", "").strip()
+    if not token or not chat:
+        print(
+            "❌ AUDIT_SEND_TELEGRAM=1 pero faltan token o chat_id.",
+            file=sys.stderr,
+        )
+        return False
+    try:
+        import requests
+    except ImportError:
+        print("❌ pip install requests", file=sys.stderr)
+        return False
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    try:
+        r = requests.post(
+            url,
+            json={"chat_id": chat, "text": texto},
+            timeout=30,
+        )
+        if r.status_code == 200:
+            print("✅ Auditoría enviada a Telegram.")
+            return True
+        print(f"❌ Telegram HTTP {r.status_code}: {r.text[:300]}", file=sys.stderr)
+    except Exception as e:
+        print(f"❌ Telegram: {e}", file=sys.stderr)
+    return False
+
+
+def main() -> int:
+    result = check_bank_impact()
+    texto = formato_consola(result)
+    print(texto)
+
+    if os.environ.get("AUDIT_SEND_TELEGRAM", "").strip() in ("1", "true", "yes"):
+        _enviar_telegram(texto)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/orchestrator_v10_final.py
+++ b/orchestrator_v10_final.py
@@ -45,6 +45,7 @@ Subcomandos:
   gcs-core          desplegar_v10_core_gcs
   sacmuseum         sacmuseum_empire — soberanía económica (kill-switch + eventos)
   auditoria         auditoria_impacto_matinal — clearing bancario Lafayette/LVMH
+  liquidez          auditoria_impacto_matinal --liquidez (monitor SEPA en tiempo real)
 """
 
 
@@ -96,6 +97,10 @@ def main() -> int:
     s.add_parser(
         "auditoria",
         help="auditoria_impacto_matinal: clearing bancario Lafayette/LVMH",
+    )
+    s.add_parser(
+        "liquidez",
+        help="auditoria_impacto_matinal --liquidez: monitor SEPA en tiempo real",
     )
 
     args = p.parse_args()
@@ -198,6 +203,10 @@ def main() -> int:
         from auditoria_impacto_matinal import main as m
 
         return m()
+    if args.cmd == "liquidez":
+        from auditoria_impacto_matinal import main as m
+
+        return m(["--liquidez"])
 
     return 2
 

--- a/orchestrator_v10_final.py
+++ b/orchestrator_v10_final.py
@@ -44,6 +44,7 @@ Subcomandos:
   gcs-contrato      despliegue_gcs_soberano_v10
   gcs-core          desplegar_v10_core_gcs
   sacmuseum         sacmuseum_empire — soberanía económica (kill-switch + eventos)
+  auditoria         auditoria_impacto_matinal — clearing bancario Lafayette/LVMH
 """
 
 
@@ -91,6 +92,10 @@ def main() -> int:
     s.add_parser(
         "sacmuseum",
         help="sacmuseum_empire: kill-switch Lafayette, nodos CP, RelicValue, log fiestas",
+    )
+    s.add_parser(
+        "auditoria",
+        help="auditoria_impacto_matinal: clearing bancario Lafayette/LVMH",
     )
 
     args = p.parse_args()
@@ -189,6 +194,10 @@ def main() -> int:
 
         run_sacmuseum_sovereignty()
         return 0
+    if args.cmd == "auditoria":
+        from auditoria_impacto_matinal import main as m
+
+        return m()
 
     return 2
 

--- a/tests/test_auditoria_impacto_matinal.py
+++ b/tests/test_auditoria_impacto_matinal.py
@@ -11,8 +11,11 @@ from auditoria_impacto_matinal import (
     CLEARING_HOUR,
     INGRESOS_ESPERADOS,
     OBJETIVO_TOTAL,
+    SEPA_SWEEP_MARGIN_MINUTES,
     check_bank_impact,
+    check_immediate_liquidity,
     formato_consola,
+    formato_liquidez,
     main,
 )
 
@@ -81,13 +84,78 @@ class TestFormatoConsola(unittest.TestCase):
         self.assertIn("Protocolo de Soberanía V10", text)
 
 
+class TestCheckImmediateLiquidity(unittest.TestCase):
+    def test_before_sweep_returns_minutes(self) -> None:
+        result = check_immediate_liquidity(now=datetime(2026, 4, 10, 7, 30))
+        self.assertFalse(result["sweep_started"])
+        self.assertEqual(result["minutes_left"], 90)
+        self.assertIn("EN TRÁNSITO", result["status"])
+        self.assertIn("90 minutos", result["status"])
+        self.assertIn("SEPA", result["status"])
+
+    def test_after_sweep_started(self) -> None:
+        result = check_immediate_liquidity(now=datetime(2026, 4, 10, 9, 5))
+        self.assertTrue(result["sweep_started"])
+        self.assertEqual(result["minutes_left"], 0)
+        self.assertIn("BARRIDO INICIADO", result["status"])
+        self.assertIn(str(SEPA_SWEEP_MARGIN_MINUTES), result["status"])
+
+    def test_at_exactly_nine(self) -> None:
+        result = check_immediate_liquidity(now=datetime(2026, 4, 10, 9, 0))
+        self.assertTrue(result["sweep_started"])
+
+    def test_at_midnight(self) -> None:
+        result = check_immediate_liquidity(now=datetime(2026, 4, 10, 0, 0))
+        self.assertFalse(result["sweep_started"])
+        self.assertEqual(result["minutes_left"], 540)
+
+    def test_one_minute_before(self) -> None:
+        result = check_immediate_liquidity(now=datetime(2026, 4, 10, 8, 59))
+        self.assertFalse(result["sweep_started"])
+        self.assertEqual(result["minutes_left"], 1)
+
+    def test_result_has_expected_keys(self) -> None:
+        result = check_immediate_liquidity(now=datetime(2026, 4, 10, 10, 0))
+        for key in ("status", "sweep_started", "minutes_left", "timestamp"):
+            self.assertIn(key, result)
+
+    def test_timestamp_is_iso(self) -> None:
+        ts = datetime(2026, 4, 10, 6, 45)
+        result = check_immediate_liquidity(now=ts)
+        self.assertEqual(result["timestamp"], ts.isoformat())
+
+
+class TestFormatoLiquidez(unittest.TestCase):
+    def test_contains_header(self) -> None:
+        result = check_immediate_liquidity(now=datetime(2026, 4, 10, 8, 0))
+        text = formato_liquidez(result)
+        self.assertIn("MONITOR DE LIQUIDEZ", text)
+
+    def test_contains_patent(self) -> None:
+        result = check_immediate_liquidity(now=datetime(2026, 4, 10, 10, 0))
+        text = formato_liquidez(result)
+        self.assertIn("PCT/EP2025/067317", text)
+        self.assertIn("Protocolo de Soberanía V10", text)
+
+
 class TestMain(unittest.TestCase):
     def test_main_returns_zero(self) -> None:
         buf = io.StringIO()
         with redirect_stdout(buf):
-            rc = main()
+            rc = main([])
         self.assertEqual(rc, 0)
-        self.assertIn("AUDITORÍA DE IMPACTO MATINAL", buf.getvalue())
+        output = buf.getvalue()
+        self.assertIn("AUDITORÍA DE IMPACTO MATINAL", output)
+        self.assertIn("MONITOR DE LIQUIDEZ", output)
+
+    def test_main_liquidez_only(self) -> None:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = main(["--liquidez"])
+        self.assertEqual(rc, 0)
+        output = buf.getvalue()
+        self.assertNotIn("AUDITORÍA DE IMPACTO MATINAL", output)
+        self.assertIn("MONITOR DE LIQUIDEZ", output)
 
 
 if __name__ == "__main__":

--- a/tests/test_auditoria_impacto_matinal.py
+++ b/tests/test_auditoria_impacto_matinal.py
@@ -1,0 +1,94 @@
+"""Tests for auditoria_impacto_matinal.py (Protocolo V10)."""
+
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stdout
+from datetime import datetime
+
+from auditoria_impacto_matinal import (
+    CLEARING_HOUR,
+    INGRESOS_ESPERADOS,
+    OBJETIVO_TOTAL,
+    check_bank_impact,
+    formato_consola,
+    main,
+)
+
+
+class TestCheckBankImpact(unittest.TestCase):
+    def test_clearing_done_after_nine(self) -> None:
+        result = check_bank_impact(now=datetime(2026, 4, 10, 10, 30))
+        self.assertTrue(result["clearing"])
+        self.assertIn("clearing ha finalizado", result["status"])
+
+    def test_clearing_not_done_before_nine(self) -> None:
+        result = check_bank_impact(now=datetime(2026, 4, 10, 7, 45))
+        self.assertFalse(result["clearing"])
+        self.assertIn("Faltan", result["status"])
+        self.assertIn("barrido bancario", result["status"])
+
+    def test_clearing_at_exactly_nine(self) -> None:
+        result = check_bank_impact(now=datetime(2026, 4, 10, 9, 0))
+        self.assertTrue(result["clearing"])
+
+    def test_clearing_at_midnight(self) -> None:
+        result = check_bank_impact(now=datetime(2026, 4, 10, 0, 0))
+        self.assertFalse(result["clearing"])
+
+    def test_result_has_expected_keys(self) -> None:
+        result = check_bank_impact(now=datetime(2026, 4, 10, 12, 0))
+        for key in ("status", "clearing", "objetivo", "ingresos", "timestamp"):
+            self.assertIn(key, result)
+
+    def test_objetivo_matches_constant(self) -> None:
+        result = check_bank_impact(now=datetime(2026, 4, 10, 12, 0))
+        self.assertEqual(result["objetivo"], OBJETIVO_TOTAL)
+
+    def test_ingresos_match_constants(self) -> None:
+        result = check_bank_impact(now=datetime(2026, 4, 10, 12, 0))
+        self.assertEqual(result["ingresos"], INGRESOS_ESPERADOS)
+
+    def test_timestamp_is_iso(self) -> None:
+        ts = datetime(2026, 4, 10, 8, 15)
+        result = check_bank_impact(now=ts)
+        self.assertEqual(result["timestamp"], ts.isoformat())
+
+    def test_minutes_remaining_calculation(self) -> None:
+        result = check_bank_impact(now=datetime(2026, 4, 10, 8, 30))
+        self.assertIn("30 minutos", result["status"])
+
+
+class TestFormatoConsola(unittest.TestCase):
+    def test_contains_header(self) -> None:
+        result = check_bank_impact(now=datetime(2026, 4, 10, 10, 0))
+        text = formato_consola(result)
+        self.assertIn("AUDITORÍA DE IMPACTO MATINAL", text)
+
+    def test_contains_ingresos(self) -> None:
+        result = check_bank_impact(now=datetime(2026, 4, 10, 10, 0))
+        text = formato_consola(result)
+        self.assertIn("Lafayette", text)
+        self.assertIn("LVMH", text)
+        self.assertIn("27,500.00", text)
+        self.assertIn("22,500.00", text)
+
+    def test_contains_patent(self) -> None:
+        result = check_bank_impact(now=datetime(2026, 4, 10, 10, 0))
+        text = formato_consola(result)
+        self.assertIn("PCT/EP2025/067317", text)
+        self.assertIn("Protocolo de Soberanía V10", text)
+
+
+class TestMain(unittest.TestCase):
+    def test_main_returns_zero(self) -> None:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = main()
+        self.assertEqual(rc, 0)
+        self.assertIn("AUDITORÍA DE IMPACTO MATINAL", buf.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `auditoria_impacto_matinal.py` — a dual-purpose V10 module for morning bank clearing verification (Lafayette / LVMH) and real-time SEPA liquidity monitoring.

## What changed

### `auditoria_impacto_matinal.py` (new)

Two complementary functions:

- **`check_bank_impact()`** — Structured daily audit of expected ingresos (Lafayette 27,500 €, LVMH 22,500 €) against a 405,680 € target. Reports clearing status based on the 09:00 window.
- **`check_immediate_liquidity()`** — Minute-level SEPA sweep countdown. Returns `EN TRÁNSITO` with minutes remaining before 09:00, or `BARRIDO INICIADO` with a 15-minute review window after.

CLI supports:
- `python3 auditoria_impacto_matinal.py` → full audit (both flows)
- `python3 auditoria_impacto_matinal.py --liquidez` → SEPA monitor only
- Optional Telegram delivery via `AUDIT_SEND_TELEGRAM=1`

### `orchestrator_v10_final.py`

Two new subcommands:
- `auditoria` → runs the full audit
- `liquidez` → runs SEPA-only monitor (`--liquidez`)

### `tests/test_auditoria_impacto_matinal.py` (new)

23 unit tests covering:
- `check_bank_impact` — clearing states, boundary cases (midnight, exactly 09:00, after), key structure, minute calculation
- `check_immediate_liquidity` — SEPA sweep states, minute countdown precision (1 min, 90 min, 540 min), boundary at 09:00
- `formato_consola` / `formato_liquidez` — output formatting, patent/protocol stamps
- `main()` — both default and `--liquidez` modes

## Test results

All 202 tests pass (the 1 pre-existing timeout in `test_supercommit_max.py` is unrelated).

```
Ran 202 tests in 30.556s
```

Patente: PCT/EP2025/067317 — Bajo Protocolo de Soberanía V10 - Founder: Rubén
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://tryonyou.slack.com/archives/D0AP1MQ3517/p1775710066192989?thread_ts=1775710066.192989&cid=D0AP1MQ3517)

<div><a href="https://cursor.com/agents/bc-22426dc9-0f2a-538f-babe-c2af062a6fd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22426dc9-0f2a-538f-babe-c2af062a6fd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

