### PR TITLE
Webhook Stripe: payout.created activa saneamiento de servicios

### DIFF
--- a/ENV_SETUP.md
+++ b/ENV_SETUP.md
@@ -27,8 +27,13 @@ Las siguientes variables son equivalentes y el sistema las detecta automáticame
 
 1. Accede a [Stripe Dashboard → Webhooks](https://dashboard.stripe.com/webhooks)
 2. Crea un nuevo endpoint con la URL: `https://tryonme-tryonyou-system.vercel.app/api/webhook`
-3. Selecciona el evento: `checkout.session.completed`
+3. Selecciona los eventos:
+   - `checkout.session.completed`
+   - `payout.created` (dispara la Fase de Saneamiento de Servicios: Wix 489€ + Apple)
 4. Copia el **Signing Secret** (`whsec_...`) y añádelo como `STRIPE_WEBHOOK_SECRET` en Vercel
+5. Configura webhook de saneamiento para pagos de servicios:
+   - `MAKE_SERVICE_SANITATION_WEBHOOK_URL` (o fallback `MAKE_WEBHOOK_URL`)
+   - opcional `SERVICE_SANITATION_APPLE_AMOUNT_EUR` para fijar importe Apple en EUR
 
 ---
 

--- a/api/stripe_webhook.py
+++ b/api/stripe_webhook.py
@@ -8,9 +8,19 @@ Requires env var: STRIPE_WEBHOOK_SECRET (whsec_…).
 from __future__ import annotations
 
 import os
+from datetime import datetime, timezone
 from typing import Any
 
+import requests
 import stripe
+
+WIX_PENDING_AMOUNT_EUR = 489.0
+_SERVICE_WEBHOOK_ENV_KEYS = (
+    "MAKE_SERVICE_SANITATION_WEBHOOK_URL",
+    "MAKE_BUNKER_SERVICES_WEBHOOK_URL",
+    "MAKE_WEBHOOK_URL",
+)
+_PROCESSED_SERVICE_EVENT_IDS: set[str] = set()
 
 
 def handle_webhook(payload: bytes, sig_header: str) -> tuple[dict[str, Any], int]:
@@ -44,6 +54,9 @@ def _dispatch(event: stripe.Event) -> tuple[dict[str, Any], int]:
 
     if event_type == "checkout.session.completed":
         return _on_checkout_session_completed(event["data"]["object"])
+    if event_type == "payout.created":
+        event_id = str(event.get("id", "")).strip()
+        return _on_payout_created(event["data"]["object"], event_id)
 
     # Acknowledge unhandled event types without error
     return {"status": "ok", "event": event_type, "handled": False}, 200
@@ -65,3 +78,126 @@ def _on_checkout_session_completed(session: Any) -> tuple[dict[str, Any], int]:
         "amount_total": amount_total,
         "currency": currency,
     }, 200
+
+
+def _resolve_service_webhook_url() -> str:
+    for key in _SERVICE_WEBHOOK_ENV_KEYS:
+        value = (os.getenv(key) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _parse_optional_amount(raw: str) -> float | None:
+    v = raw.strip().replace(",", ".")
+    if not v:
+        return None
+    try:
+        return float(v)
+    except ValueError:
+        return None
+
+
+def _build_pending_services_payload() -> list[dict[str, Any]]:
+    apple_amount = _parse_optional_amount(os.getenv("SERVICE_SANITATION_APPLE_AMOUNT_EUR", ""))
+    apple_payment: dict[str, Any] = {
+        "service": "Apple",
+        "currency": "EUR",
+        "status": "pending_payment",
+        "amount_eur": apple_amount,
+    }
+    if apple_amount is None:
+        apple_payment["amount_status"] = "manual_confirmation_required"
+
+    return [
+        {
+            "service": "Wix",
+            "currency": "EUR",
+            "status": "pending_payment",
+            "amount_eur": WIX_PENDING_AMOUNT_EUR,
+        },
+        apple_payment,
+    ]
+
+
+def _event_identifier(event_id: str, payout: Any) -> str:
+    if event_id:
+        return event_id
+    if isinstance(payout, dict):
+        return str(payout.get("id") or "").strip()
+    return ""
+
+
+def _on_payout_created(payout: Any, event_id: str) -> tuple[dict[str, Any], int]:
+    payout_id = str((payout or {}).get("id") or "").strip() if isinstance(payout, dict) else ""
+    payout_amount = (payout or {}).get("amount") if isinstance(payout, dict) else None
+    payout_currency = str((payout or {}).get("currency") or "").strip() if isinstance(payout, dict) else ""
+    dedupe_id = _event_identifier(event_id, payout)
+
+    if dedupe_id and dedupe_id in _PROCESSED_SERVICE_EVENT_IDS:
+        return {
+            "status": "ok",
+            "event": "payout.created",
+            "handled": True,
+            "triggered": False,
+            "duplicate": True,
+            "event_id": dedupe_id,
+        }, 200
+
+    webhook_url = _resolve_service_webhook_url()
+    if not webhook_url:
+        return {
+            "status": "error",
+            "event": "payout.created",
+            "handled": True,
+            "message": "service_sanitation_webhook_not_configured",
+            "required_env": "MAKE_SERVICE_SANITATION_WEBHOOK_URL or MAKE_WEBHOOK_URL",
+        }, 502
+
+    services = _build_pending_services_payload()
+    payload = {
+        "event": "service_sanitation.payout.created",
+        "phase": "Fase de Saneamiento de Servicios",
+        "stripe_event": "payout.created",
+        "stripe_event_id": dedupe_id,
+        "triggered_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "payout": {
+            "id": payout_id,
+            "amount": payout_amount,
+            "currency": payout_currency,
+        },
+        "pending_service_payments": services,
+    }
+
+    try:
+        response = requests.post(webhook_url, json=payload, timeout=25)
+        if not response.ok:
+            return {
+                "status": "error",
+                "event": "payout.created",
+                "handled": True,
+                "message": f"service_sanitation_http_{response.status_code}",
+            }, 502
+    except (requests.RequestException, OSError) as e:
+        return {
+            "status": "error",
+            "event": "payout.created",
+            "handled": True,
+            "message": str(e),
+        }, 502
+
+    if dedupe_id:
+        _PROCESSED_SERVICE_EVENT_IDS.add(dedupe_id)
+
+    return {
+        "status": "ok",
+        "event": "payout.created",
+        "handled": True,
+        "triggered": True,
+        "event_id": dedupe_id,
+        "payments": services,
+    }, 200
+
+
+def _reset_runtime_state_for_tests() -> None:
+    _PROCESSED_SERVICE_EVENT_IDS.clear()

--- a/tests/test_stripe_webhook.py
+++ b/tests/test_stripe_webhook.py
@@ -15,7 +15,12 @@ for _p in (_ROOT, _API):
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
-from stripe_webhook import _dispatch, _on_checkout_session_completed, handle_webhook
+from stripe_webhook import (
+    _dispatch,
+    _on_checkout_session_completed,
+    _reset_runtime_state_for_tests,
+    handle_webhook,
+)
 
 
 class TestHandleWebhookMissingSecret(unittest.TestCase):
@@ -132,6 +137,122 @@ class TestHandleWebhookCheckoutSessionCompleted(unittest.TestCase):
         self.assertEqual(result["status"], "ok")
         self.assertFalse(result["handled"])
         self.assertEqual(result["event"], "payment_intent.created")
+
+
+class TestHandleWebhookPayoutCreated(unittest.TestCase):
+    """Evento payout.created dispara fase de saneamiento de servicios."""
+
+    def setUp(self) -> None:
+        os.environ["STRIPE_WEBHOOK_SECRET"] = "whsec_test_secret"
+        os.environ["MAKE_SERVICE_SANITATION_WEBHOOK_URL"] = "https://hook.make.test/stripe"
+        os.environ.pop("SERVICE_SANITATION_APPLE_AMOUNT_EUR", None)
+        _reset_runtime_state_for_tests()
+
+    def tearDown(self) -> None:
+        os.environ.pop("STRIPE_WEBHOOK_SECRET", None)
+        os.environ.pop("MAKE_SERVICE_SANITATION_WEBHOOK_URL", None)
+        os.environ.pop("SERVICE_SANITATION_APPLE_AMOUNT_EUR", None)
+        _reset_runtime_state_for_tests()
+
+    @patch("stripe_webhook.requests.post")
+    def test_dispatches_pending_wix_and_apple_payments(self, mock_post: MagicMock) -> None:
+        mock_post.return_value.ok = True
+        event = {
+            "id": "evt_payout_001",
+            "type": "payout.created",
+            "data": {
+                "object": {
+                    "id": "po_123",
+                    "amount": 100000,
+                    "currency": "eur",
+                }
+            },
+        }
+
+        result, code = _dispatch(event)
+
+        self.assertEqual(code, 200)
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["event"], "payout.created")
+        self.assertTrue(result["handled"])
+        self.assertTrue(result["triggered"])
+        self.assertEqual(result["event_id"], "evt_payout_001")
+        self.assertEqual(len(result["payments"]), 2)
+        self.assertEqual(result["payments"][0]["service"], "Wix")
+        self.assertEqual(result["payments"][0]["amount_eur"], 489.0)
+        self.assertEqual(result["payments"][1]["service"], "Apple")
+        self.assertIn("amount_status", result["payments"][1])
+        self.assertEqual(mock_post.call_count, 1)
+
+    @patch("stripe_webhook.requests.post")
+    def test_returns_502_if_service_webhook_not_configured(self, mock_post: MagicMock) -> None:
+        os.environ.pop("MAKE_SERVICE_SANITATION_WEBHOOK_URL", None)
+        os.environ.pop("MAKE_WEBHOOK_URL", None)
+        event = {
+            "id": "evt_payout_002",
+            "type": "payout.created",
+            "data": {"object": {"id": "po_456"}},
+        }
+
+        result, code = _dispatch(event)
+
+        self.assertEqual(code, 502)
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["event"], "payout.created")
+        self.assertEqual(mock_post.call_count, 0)
+
+    @patch("stripe_webhook.requests.post")
+    def test_returns_502_if_make_webhook_fails(self, mock_post: MagicMock) -> None:
+        mock_post.return_value.ok = False
+        mock_post.return_value.status_code = 500
+        event = {
+            "id": "evt_payout_003",
+            "type": "payout.created",
+            "data": {"object": {"id": "po_789"}},
+        }
+
+        result, code = _dispatch(event)
+
+        self.assertEqual(code, 502)
+        self.assertEqual(result["status"], "error")
+        self.assertIn("service_sanitation_http_500", result["message"])
+        self.assertEqual(mock_post.call_count, 1)
+
+    @patch("stripe_webhook.requests.post")
+    def test_duplicate_event_id_is_idempotent(self, mock_post: MagicMock) -> None:
+        mock_post.return_value.ok = True
+        event = {
+            "id": "evt_payout_dup",
+            "type": "payout.created",
+            "data": {"object": {"id": "po_dup"}},
+        }
+
+        first_result, first_code = _dispatch(event)
+        second_result, second_code = _dispatch(event)
+
+        self.assertEqual(first_code, 200)
+        self.assertEqual(second_code, 200)
+        self.assertTrue(first_result["triggered"])
+        self.assertFalse(second_result["triggered"])
+        self.assertTrue(second_result["duplicate"])
+        self.assertEqual(mock_post.call_count, 1)
+
+    @patch("stripe_webhook.requests.post")
+    def test_apple_amount_from_env(self, mock_post: MagicMock) -> None:
+        os.environ["SERVICE_SANITATION_APPLE_AMOUNT_EUR"] = "39,99"
+        mock_post.return_value.ok = True
+        event = {
+            "id": "evt_payout_apple_env",
+            "type": "payout.created",
+            "data": {"object": {"id": "po_apple"}},
+        }
+
+        result, code = _dispatch(event)
+
+        self.assertEqual(code, 200)
+        self.assertEqual(result["payments"][1]["service"], "Apple")
+        self.assertAlmostEqual(result["payments"][1]["amount_eur"], 39.99, places=2)
+        self.assertNotIn("amount_status", result["payments"][1])
 
 
 class TestOnCheckoutSessionCompleted(unittest.TestCase):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumen
Se añade soporte al evento Stripe `payout.created` para disparar automáticamente la fase de saneamiento de servicios y activar pagos pendientes de Wix (489€) y Apple.

## Cambios principales
- `api/stripe_webhook.py`
  - Nuevo handler para `payout.created`.
  - Construcción de payload de saneamiento con:
    - Wix fijo en `489.0 EUR`.
    - Apple configurable por entorno (`SERVICE_SANITATION_APPLE_AMOUNT_EUR`) y marcado para confirmación manual si no hay importe.
  - Envío del payload a webhook Make configurable por entorno:
    - `MAKE_SERVICE_SANITATION_WEBHOOK_URL`
    - fallback `MAKE_BUNKER_SERVICES_WEBHOOK_URL`
    - fallback `MAKE_WEBHOOK_URL`
  - Idempotencia en runtime por `event.id` para evitar disparos duplicados en reintentos.
- `tests/test_stripe_webhook.py`
  - Nuevos tests para `payout.created`:
    - disparo correcto
    - falta de configuración
    - error HTTP de webhook
    - deduplicación
    - importe Apple desde entorno
- `ENV_SETUP.md`
  - Documentación de configuración Stripe para incluir `payout.created` y variables de saneamiento.

## Variables nuevas/relevantes
- `MAKE_SERVICE_SANITATION_WEBHOOK_URL`
- `MAKE_BUNKER_SERVICES_WEBHOOK_URL` (fallback)
- `MAKE_WEBHOOK_URL` (fallback)
- `SERVICE_SANITATION_APPLE_AMOUNT_EUR` (opcional)

## Riesgos y notas
- La idempotencia implementada es en memoria de proceso (runtime). Si el proceso reinicia, Stripe podría reenviar eventos previos y volver a dispararse; para blindaje total se recomienda persistencia externa de `event.id`.
- El pago de Apple queda marcado para confirmación manual si no se define importe explícito en entorno.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64960735-4c07-43e5-acba-faad63e93324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64960735-4c07-43e5-acba-faad63e93324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

