### PR TITLE
Añadir AGENTS.md — Instrucciones Cursor Cloud para entorno de desarrollo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Servicios principales
+
+| Servicio | Comando | Puerto | Notas |
+|----------|---------|--------|-------|
+| **Frontend (Vite)** | `npm run dev` | 5173 | SPA React + Tailwind; proxifica `/api` → `localhost:8000` |
+| **API (Flask)** | `flask --app api.index run --port 8000` | 8000 | Requiere `PATH` incluya `~/.local/bin` si pip instaló con `--user` |
+
+### Cómo ejecutar
+
+- **Typecheck:** `npx tsc --noEmit`
+- **Build:** `npm run build` (ejecuta prebuild assert-firebase-applet antes de vite build)
+- **Dev server:** Arrancar Flask API y luego Vite dev. Ver tabla de servicios.
+- No existe linter ESLint configurado; el typecheck de TypeScript (`tsc --noEmit`) es la validación estática principal.
+
+### Notas importantes
+
+- El `.env` se crea copiando `.env.example`. Las claves de Stripe/Firebase son opcionales para el desarrollo local básico; la API responde en `/api/health` sin ellas.
+- El prebuild (`scripts/assert-firebase-applet.mjs`) valida que `firebase-applet-config.json` exista con `projectId = gen-lang-client-0066102635`. No modificar ese archivo.
+- Los voice agents (`tryonme-voice-agent/`, `voice_agent/`) y el backend omega (`backend/`) son servicios independientes con sus propios `requirements.txt`. No son necesarios para la app web principal.
+- Flask se instala vía `pip install --user`, por lo que el binario queda en `~/.local/bin`. Asegúrate de que esté en `PATH`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumen

Añade `AGENTS.md` con instrucciones específicas para agentes Cursor Cloud que trabajen en este repositorio.

### Cambios

- Creación de `AGENTS.md` con sección `## Cursor Cloud specific instructions`
  - Tabla de servicios principales (Frontend Vite en 5173, Flask API en 8000)
  - Comandos para typecheck, build y dev server
  - Notas sobre `.env`, Firebase config, y voice agents independientes

### Validación del entorno

| Verificación | Resultado |
|-------------|-----------|
| `npm install` | ✅ 176 paquetes, 0 vulnerabilidades |
| `pip install -r requirements.txt` | ✅ Flask, httpx, stripe, pandas instalados |
| `npx tsc --noEmit` | ✅ Sin errores TypeScript |
| `npm run build` | ✅ Build completo en 1.02s |
| Flask API `/api/health` | ✅ Responde `{"status": "ok", "version": "V10.4_Lafayette"}` |
| Vite dev server | ✅ Puerto 5173 operativo |
| Proxy Vite → Flask | ✅ `/api/health` proxificado correctamente |
| Formulario waitlist | ✅ Registro de email funcional |

### Demo

[tryonyou_app_demo.mp4](https://cursor.com/agents/bc-e8ec6be8-1b76-4bc8-8668-075348387cf4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftryonyou_app_demo.mp4)

[Landing page en francés](https://cursor.com/agents/bc-e8ec6be8-1b76-4bc8-8668-075348387cf4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flanding_page_french.webp)
[Confirmación de registro waitlist](https://cursor.com/agents/bc-e8ec6be8-1b76-4bc8-8668-075348387cf4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwaitlist_success.webp)
[Landing page en inglés](https://cursor.com/agents/bc-e8ec6be8-1b76-4bc8-8668-075348387cf4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flanding_page_english.webp)

PCT/EP2025/067317 — Bajo Protocolo de Soberanía V10 - Founder: Rubén

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8ec6be8-1b76-4bc8-8668-075348387cf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8ec6be8-1b76-4bc8-8668-075348387cf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

