### PR TITLE
docs(AGENTS.md): add camera feed note for Cloud Agent environments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,4 @@
 - El prebuild (`scripts/assert-firebase-applet.mjs`) valida que `firebase-applet-config.json` exista con `projectId = gen-lang-client-0066102635`. No modificar ese archivo.
 - Los voice agents (`tryonme-voice-agent/`, `voice_agent/`) y el backend omega (`backend/`) son servicios independientes con sus propios `requirements.txt`. No son necesarios para la app web principal.
 - Flask se instala vía `pip install --user`, por lo que el binario queda en `~/.local/bin`. Asegúrate de que esté en `PATH`.
+- Al abrir la app en un entorno sin webcam (como Cloud Agent), aparecerán alertas `"Failed to acquire camera feed: NotFoundError"`. Esto es esperado y no impide el uso general de la app; solo afecta a las funciones biométricas de MediaPipe.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Cambios

Añade una nota en `AGENTS.md` sobre el comportamiento esperado de la alerta `"Failed to acquire camera feed: NotFoundError"` en entornos sin webcam (como Cloud Agent VMs). Esto evita confusión en futuros agentes al ver esos errores durante el testing manual.

## Verificación del entorno de desarrollo

Todos los servicios principales han sido verificados:

| Servicio | Estado | Comando |
|----------|--------|---------|
| **Typecheck** | ✅ Pasa | `npx tsc --noEmit` |
| **Build** | ✅ Pasa | `npm run build` |
| **Flask API** | ✅ Responde | `flask --app api.index run --port 8000` → `/api/health` OK |
| **Vite Dev** | ✅ Carga | `npm run dev` → `localhost:5173` HTTP 200 |
| **Proxy API** | ✅ Funciona | `localhost:5173/api/health` proxifica correctamente |

## Demo

[tryonyou_app_demo.mp4](https://cursor.com/agents/bc-e05e087c-9ce1-48c6-9b39-8ba2166b4511/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftryonyou_app_demo.mp4)

App cargada, formulario de waitlist probado con email, cambio de idioma FR/EN/ES verificado.

[Homepage en francés](https://cursor.com/agents/bc-e05e087c-9ce1-48c6-9b39-8ba2166b4511/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_fr.webp)
[Confirmación de email waitlist](https://cursor.com/agents/bc-e05e087c-9ce1-48c6-9b39-8ba2166b4511/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Femail_waitlist_success.webp)
[Homepage en inglés](https://cursor.com/agents/bc-e05e087c-9ce1-48c6-9b39-8ba2166b4511/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_en.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e05e087c-9ce1-48c6-9b39-8ba2166b4511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e05e087c-9ce1-48c6-9b39-8ba2166b4511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

