### PR TITLE
feat: Financial Sanitization V11 + Territory Expansion + Ethical Manifesto Seal

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -27,6 +27,16 @@ from qonto_iban_transfer import (
     validate_transfer_readiness,
 )
 from invoice_generator import generate_proforma
+from treasury_monitor import (
+    get_treasury_status,
+    get_payouts_list,
+    record_payout,
+)
+from territory_expansion import (
+    get_expansion_nodes,
+    get_territory_summary,
+    generate_node_contract,
+)
 
 app = Flask(__name__)
 
@@ -346,6 +356,95 @@ def invoice_proforma():
     })), 200
 
 
+# ── V11 Treasury: Payout Monitoring & Capital Blindaje ───────────────
+
+@app.route("/api/v1/treasury/status", methods=["OPTIONS"])
+def treasury_status_options():
+    return _cors(Response(status=204))
+
+
+@app.route("/api/v1/treasury/status", methods=["GET"])
+def treasury_status():
+    status = get_treasury_status()
+    return _cors(jsonify({"status": "ok", **status})), 200
+
+
+@app.route("/api/v1/treasury/payouts", methods=["OPTIONS"])
+def treasury_payouts_options():
+    return _cors(Response(status=204))
+
+
+@app.route("/api/v1/treasury/payouts", methods=["GET"])
+def treasury_payouts_list():
+    payouts = get_payouts_list()
+    return _cors(jsonify({
+        "status": "ok",
+        "payouts": payouts,
+        "count": len(payouts),
+    })), 200
+
+
+@app.route("/api/v1/treasury/payouts", methods=["POST"])
+def treasury_record_payout():
+    body = request.get_json(force=True, silent=True) or {}
+    amount = body.get("amount_eur")
+    if not amount or not isinstance(amount, (int, float)) or amount <= 0:
+        return _cors(jsonify({
+            "status": "error",
+            "message": "amount_eur_required_positive",
+        })), 400
+
+    entry = record_payout(
+        amount_eur=float(amount),
+        recipient=str(body.get("recipient", "")).strip(),
+        concept=str(body.get("concept", "operational")).strip(),
+    )
+    return _cors(jsonify({"status": "ok", "payout": entry})), 201
+
+
+# ── V11 Territory: Multi-Node Expansion & Licensing ─────────────────
+
+@app.route("/api/v1/territory/nodes", methods=["OPTIONS"])
+def territory_nodes_options():
+    return _cors(Response(status=204))
+
+
+@app.route("/api/v1/territory/nodes", methods=["GET"])
+def territory_nodes():
+    nodes = get_expansion_nodes()
+    summary = get_territory_summary()
+    return _cors(jsonify({
+        "status": "ok",
+        "nodes": nodes,
+        "summary": summary,
+    })), 200
+
+
+@app.route("/api/v1/territory/contracts", methods=["OPTIONS"])
+def territory_contracts_options():
+    return _cors(Response(status=204))
+
+
+@app.route("/api/v1/territory/contracts", methods=["POST"])
+def territory_generate_contract():
+    body = request.get_json(force=True, silent=True) or {}
+    node_id = str(body.get("node_id", "")).strip()
+    if not node_id:
+        return _cors(jsonify({
+            "status": "error",
+            "message": "node_id_required",
+        })), 400
+
+    contract = generate_node_contract(node_id)
+    if not contract:
+        return _cors(jsonify({
+            "status": "error",
+            "message": "node_not_found",
+        })), 404
+
+    return _cors(jsonify({"status": "ok", "contract": contract})), 201
+
+
 @app.route("/api/health", methods=["GET"])
 @app.route("/health", methods=["GET"])
 def health():
@@ -364,10 +463,13 @@ def health():
     ).strip()
     webhook_secret = (os.getenv("STRIPE_WEBHOOK_SECRET") or "").strip()
 
+    territory = get_territory_summary()
+    treasury = get_treasury_status()
+
     return _cors(jsonify({
         "ok": True,
         "status": "ok",
-        "version": "V11.0_Lafayette_Sovereign",
+        "version": "V11.1_Expansion_Sovereign",
         "service": "tryonyou_v11_omega",
         "product_lane": "tryonyou_v11_sovereign",
         "siren": "943610196",
@@ -378,4 +480,9 @@ def health():
         "webhook_secret_set": bool(webhook_secret),
         "iban_transfer_configured": is_iban_transfer_configured(),
         "payment_method": "DIRECT_IBAN_TRANSFER" if is_iban_transfer_configured() else "STRIPE",
+        "territory_active_nodes": territory["active_nodes"],
+        "territory_pending_nodes": territory["pending_nodes"],
+        "territory_expansion_target_eur": territory["expansion_target_eur"],
+        "treasury_reserve_eur": treasury["reserve_eur"],
+        "treasury_capital_label": treasury["capital_label"],
     })), 200

--- a/api/territory_expansion.py
+++ b/api/territory_expansion.py
@@ -1,0 +1,147 @@
+"""
+Territory Expansion — Multi-node licensing V11.
+
+Manages the expansion map of TryOnYou deployment nodes beyond the
+founding Lafayette Haussmann location.  Each node has a licensing
+status, a contract amount (27 500 EUR standard V11 licence) and
+a proforma generation hook.
+
+SIRET 94361019600017 | PCT/EP2025/067317
+Bajo Protocolo de Soberanía V10 - Founder: Rubén
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+SIREN = "943 610 196"
+SIRET = "94361019600017"
+PATENT = "PCT/EP2025/067317"
+ENTITY = "EI - ESPINAR RODRIGUEZ"
+
+LICENCE_FEE_EUR = 27_500.00
+SETUP_FEE_EUR = 12_500.00
+EXCLUSIVITY_EUR = 15_000.00
+
+TERRITORY_LOG_DIR = Path("/tmp/tryonyou_territory")
+
+EXPANSION_NODES: list[dict] = [
+    {
+        "id": "lafayette-haussmann",
+        "name": "Galeries Lafayette Haussmann",
+        "city": "Paris",
+        "district": "75009",
+        "status": "ACTIVE",
+        "licence_eur": LICENCE_FEE_EUR,
+        "confirmed": True,
+    },
+    {
+        "id": "bon-marche",
+        "name": "Le Bon Marché",
+        "city": "Paris",
+        "district": "75007",
+        "status": "PENDING_LICENCE",
+        "licence_eur": LICENCE_FEE_EUR,
+        "confirmed": False,
+    },
+    {
+        "id": "le-marais",
+        "name": "Le Marais",
+        "city": "Paris",
+        "district": "75003",
+        "status": "PENDING_LICENCE",
+        "licence_eur": LICENCE_FEE_EUR,
+        "confirmed": False,
+    },
+    {
+        "id": "la-defense",
+        "name": "La Défense",
+        "city": "Paris",
+        "district": "92060",
+        "status": "PENDING_LICENCE",
+        "licence_eur": LICENCE_FEE_EUR,
+        "confirmed": False,
+    },
+]
+
+
+def get_expansion_nodes() -> list[dict]:
+    """Return all expansion nodes with their licensing status."""
+    ts = datetime.now(timezone.utc).isoformat()
+    return [
+        {**node, "patent": PATENT, "siret": SIRET, "ts": ts}
+        for node in EXPANSION_NODES
+    ]
+
+
+def get_territory_summary() -> dict:
+    """High-level territory summary for dashboards and health checks."""
+    active = [n for n in EXPANSION_NODES if n["status"] == "ACTIVE"]
+    pending = [n for n in EXPANSION_NODES if n["status"] == "PENDING_LICENCE"]
+    total_confirmed_revenue = sum(n["licence_eur"] for n in active)
+    total_pending_revenue = sum(n["licence_eur"] for n in pending)
+
+    return {
+        "entity": ENTITY,
+        "siret": SIRET,
+        "patent": PATENT,
+        "total_nodes": len(EXPANSION_NODES),
+        "active_nodes": len(active),
+        "pending_nodes": len(pending),
+        "active_names": [n["name"] for n in active],
+        "pending_names": [n["name"] for n in pending],
+        "confirmed_revenue_eur": total_confirmed_revenue,
+        "pending_revenue_eur": total_pending_revenue,
+        "expansion_target_eur": total_confirmed_revenue + total_pending_revenue,
+        "licence_fee_eur": LICENCE_FEE_EUR,
+        "ts": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def generate_node_contract(node_id: str) -> dict | None:
+    """Generate a proforma contract payload for a specific node."""
+    node = next((n for n in EXPANSION_NODES if n["id"] == node_id), None)
+    if not node:
+        return None
+
+    seq = _next_contract_seq()
+    ref = f"CTR-{datetime.now(timezone.utc).strftime('%Y%m%d')}-{seq:03d}"
+
+    contract = {
+        "ref": ref,
+        "node_id": node["id"],
+        "node_name": node["name"],
+        "city": node["city"],
+        "district": node["district"],
+        "entity": ENTITY,
+        "siret": SIRET,
+        "patent": PATENT,
+        "setup_fee_eur": SETUP_FEE_EUR,
+        "exclusivity_eur": EXCLUSIVITY_EUR,
+        "total_licence_eur": LICENCE_FEE_EUR,
+        "currency": "EUR",
+        "status": "PROFORMA",
+        "ts": datetime.now(timezone.utc).isoformat(),
+    }
+
+    try:
+        TERRITORY_LOG_DIR.mkdir(parents=True, exist_ok=True)
+        target = TERRITORY_LOG_DIR / f"{ref}.json"
+        target.write_text(
+            json.dumps(contract, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+    except OSError:
+        pass
+
+    return contract
+
+
+def _next_contract_seq() -> int:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d")
+    TERRITORY_LOG_DIR.mkdir(parents=True, exist_ok=True)
+    existing = sorted(TERRITORY_LOG_DIR.glob(f"CTR-{stamp}-*.json"))
+    return len(existing) + 1

--- a/api/treasury_monitor.py
+++ b/api/treasury_monitor.py
@@ -1,0 +1,112 @@
+"""
+Treasury Monitor — Payout tracking & capital blindaje V11.
+
+Tracks outbound fund movements (payouts) while shielding the sovereign
+capital reserve.  All amounts resolved from env or defaults — never
+hardcoded IBAN/account data.
+
+SIRET 94361019600017 | PCT/EP2025/067317
+Bajo Protocolo de Soberanía V10 - Founder: Rubén
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+SIREN = "943 610 196"
+SIRET = "94361019600017"
+PATENT = "PCT/EP2025/067317"
+ENTITY = "EI - ESPINAR RODRIGUEZ"
+
+PAYOUT_LOG_DIR = Path("/tmp/tryonyou_treasury")
+
+DEFAULT_CAPITAL = 398_744.50
+DEFAULT_PAYOUT_BUDGET = 1_600.00
+DEFAULT_PAYOUT_SLOTS = 4
+PAYOUT_AMOUNT_PER_SLOT = 400.00
+
+
+def _env(key: str, fallback: str = "") -> str:
+    return (os.getenv(key) or fallback).strip()
+
+
+def _read_capital() -> float:
+    raw = _env("TREASURY_CAPITAL_EUR", str(DEFAULT_CAPITAL))
+    try:
+        return float(raw)
+    except ValueError:
+        return DEFAULT_CAPITAL
+
+
+def _read_payout_log() -> list[dict]:
+    log_path = PAYOUT_LOG_DIR / "payouts.jsonl"
+    if not log_path.exists():
+        return []
+    entries: list[dict] = []
+    for line in log_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return entries
+
+
+def _append_payout(entry: dict) -> None:
+    PAYOUT_LOG_DIR.mkdir(parents=True, exist_ok=True)
+    log_path = PAYOUT_LOG_DIR / "payouts.jsonl"
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def get_treasury_status() -> dict:
+    """Full treasury snapshot: capital, payouts executed, reserve."""
+    capital = _read_capital()
+    payouts = _read_payout_log()
+    total_out = sum(p.get("amount_eur", 0.0) for p in payouts)
+    reserve = round(capital - total_out, 2)
+    budget = float(_env("TREASURY_PAYOUT_BUDGET_EUR", str(DEFAULT_PAYOUT_BUDGET)))
+
+    return {
+        "entity": ENTITY,
+        "siret": SIRET,
+        "siren": SIREN,
+        "patent": PATENT,
+        "capital_eur": capital,
+        "total_payouts_eur": round(total_out, 2),
+        "reserve_eur": reserve,
+        "payout_budget_eur": budget,
+        "payout_slots": DEFAULT_PAYOUT_SLOTS,
+        "payout_amount_per_slot_eur": PAYOUT_AMOUNT_PER_SLOT,
+        "payouts_executed": len(payouts),
+        "capital_label": "Capital Social Blindado",
+        "bank": "QONTO_BUSINESS",
+        "ts": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def record_payout(
+    amount_eur: float,
+    recipient: str = "",
+    concept: str = "operational",
+) -> dict:
+    """Record an outbound payout and return the updated entry."""
+    entry = {
+        "amount_eur": round(amount_eur, 2),
+        "recipient": recipient or "operational",
+        "concept": concept,
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "entity": ENTITY,
+        "siret": SIRET,
+    }
+    _append_payout(entry)
+    return entry
+
+
+def get_payouts_list() -> list[dict]:
+    """Return all recorded payouts."""
+    return _read_payout_log()

--- a/index.html
+++ b/index.html
@@ -50,6 +50,25 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 <title>TRYONME × DIVINEO</title>
+<script id="tryonyou-org-jsonld">
+(function(){
+  var d=document,s=d.createElement('script');
+  s.type='application/ld+json';
+  var o=window.location.origin;
+  s.textContent=JSON.stringify({
+    '@context':'https://schema.org','@type':'Organization',
+    'name':'TryOnYou','alternateName':'Divineo','url':o,
+    'foundingDate':'2024',
+    'founder':{'@type':'Person','name':'Rubén Espinar Rodríguez'},
+    'address':{'@type':'PostalAddress','addressLocality':'Paris','postalCode':'75011','addressCountry':'FR'},
+    'taxID':'94361019600017',
+    'knowsAbout':['Virtual try-on technology','Biometric sizing intelligence','Digital twin for fashion retail','Zero-Size Protocol'],
+    'ethicsPolicy':o+'/#ethics',
+    'slogan':'The virtual fitting room that reduces returns'
+  });
+  d.head.appendChild(s);
+})();
+</script>
 <script src="https://cdn.jsdelivr.net/npm/@mediapipe/pose/pose.js" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/@mediapipe/camera_utils/camera_utils.js" crossorigin="anonymous"></script>
   <style>

--- a/src/App.css
+++ b/src/App.css
@@ -771,6 +771,141 @@ button {
   color: #ffdcdc;
 }
 
+/* ── Expansion Network Section ────────────────────── */
+
+.expansion-banner {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 20px 24px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(199, 168, 106, 0.32);
+  background: linear-gradient(135deg, rgba(199, 168, 106, 0.12), rgba(139, 167, 255, 0.06));
+  margin-bottom: 32px;
+}
+
+.expansion-banner__icon {
+  flex-shrink: 0;
+  width: 42px;
+  height: 42px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent-premium), rgba(199, 168, 106, 0.6));
+  color: #111217;
+  font-size: 1.1rem;
+  font-weight: 800;
+}
+
+.expansion-banner__copy h3 {
+  margin: 0 0 4px;
+  font-size: 1.02rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--accent-premium);
+}
+
+.expansion-banner__copy p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.94rem;
+  line-height: 1.6;
+}
+
+.expansion-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.expansion-node {
+  position: relative;
+  border: 1px solid rgba(42, 46, 54, 0.88);
+  background: linear-gradient(180deg, rgba(20, 22, 27, 0.95), rgba(20, 22, 27, 0.82));
+  box-shadow: var(--shadow-panel);
+  border-radius: var(--radius-lg);
+  padding: 24px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  transition: border-color 240ms ease, box-shadow 240ms ease;
+}
+
+.expansion-node:hover {
+  border-color: rgba(199, 168, 106, 0.38);
+  box-shadow: 0 18px 48px rgba(199, 168, 106, 0.08);
+}
+
+.expansion-node--active {
+  border-color: rgba(199, 168, 106, 0.5);
+}
+
+.expansion-node--pending {
+  border-color: rgba(139, 167, 255, 0.28);
+}
+
+.expansion-node__badge {
+  display: inline-flex;
+  align-self: flex-start;
+  padding: 5px 12px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.expansion-node--active .expansion-node__badge {
+  background: rgba(127, 185, 143, 0.18);
+  border: 1px solid rgba(127, 185, 143, 0.4);
+  color: #a8e0b4;
+}
+
+.expansion-node--pending .expansion-node__badge {
+  background: rgba(199, 168, 106, 0.14);
+  border: 1px solid rgba(199, 168, 106, 0.36);
+  color: var(--accent-premium);
+  animation: pendingPulse 2.8s ease-in-out infinite;
+}
+
+@keyframes pendingPulse {
+  0%, 100% { opacity: 0.82; }
+  50% { opacity: 1; }
+}
+
+.expansion-node__name {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.3;
+}
+
+.expansion-node__district {
+  margin: 0;
+  font-size: 0.84rem;
+  color: var(--text-secondary);
+  letter-spacing: 0.06em;
+}
+
+@media (max-width: 1180px) {
+  .expansion-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .expansion-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .expansion-banner {
+    flex-direction: column;
+    text-align: center;
+  }
+}
+
 .site-footer {
   position: relative;
   z-index: 1;

--- a/src/App.css
+++ b/src/App.css
@@ -906,6 +906,64 @@ button {
   }
 }
 
+/* ── Ethics Manifesto Section ─────────────────────── */
+
+.ethics-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 32px;
+}
+
+.ethics-card {
+  border-color: rgba(199, 168, 106, 0.18);
+  background: linear-gradient(180deg, rgba(20, 22, 27, 0.96), rgba(14, 14, 18, 0.88));
+}
+
+.ethics-card__icon {
+  color: var(--accent-premium);
+  font-size: 1.2rem;
+  opacity: 0.8;
+}
+
+.ethics-seal {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  margin-top: 36px;
+  padding: 18px 28px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(199, 168, 106, 0.24);
+  background: linear-gradient(135deg, rgba(199, 168, 106, 0.06), rgba(139, 167, 255, 0.04));
+}
+
+.ethics-seal__mark {
+  color: var(--accent-premium);
+  font-size: 1.3rem;
+}
+
+.ethics-seal p {
+  margin: 0;
+  color: var(--accent-premium);
+  font-size: 0.88rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 1180px) {
+  .ethics-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .ethics-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 .site-footer {
   position: relative;
   z-index: 1;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -493,6 +493,49 @@ function App() {
         </motion.section>
 
         <motion.section
+          id="expansion"
+          className="section"
+          initial={{ opacity: 0, y: 24 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 0.2 }}
+          transition={{ duration: 0.65, ease: "easeOut" }}
+        >
+          <div className="section-shell">
+            <div className="section-copy">
+              <p className="section-kicker">06</p>
+              <h2>{copy.expansion.sectionTitle}</h2>
+            </div>
+
+            <div className="expansion-banner">
+              <span className="expansion-banner__icon" aria-hidden="true">
+                &#x25C8;
+              </span>
+              <div className="expansion-banner__copy">
+                <h3>{copy.expansion.bannerTitle}</h3>
+                <p>{copy.expansion.bannerBody}</p>
+              </div>
+            </div>
+
+            <div className="expansion-grid">
+              {copy.expansion.locations.map((location) => (
+                <article
+                  key={location.name}
+                  className={`expansion-node expansion-node--${location.status}`}
+                >
+                  <span className="expansion-node__badge">
+                    {location.status === "active"
+                      ? copy.expansion.activeBadge
+                      : copy.expansion.pendingBadge}
+                  </span>
+                  <h3 className="expansion-node__name">{location.name}</h3>
+                  <p className="expansion-node__district">{location.district}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        </motion.section>
+
+        <motion.section
           id="about"
           className="section"
           initial={{ opacity: 0, y: 24 }}
@@ -502,7 +545,7 @@ function App() {
         >
           <div className="section-shell cta-grid">
             <div className="section-copy">
-              <p className="section-kicker">06</p>
+              <p className="section-kicker">07</p>
               <h2>{copy.finalCta.title}</h2>
               <div className="hero-actions">
                 <a className="button button--primary" href="#demo">
@@ -535,7 +578,7 @@ function App() {
         >
           <div className="section-shell demo-grid">
             <div className="section-copy">
-              <p className="section-kicker">07</p>
+              <p className="section-kicker">08</p>
               <h2>{copy.demoForm.title}</h2>
               <p>{copy.demoForm.support}</p>
             </div>
@@ -695,7 +738,17 @@ function App() {
 
       <footer id="legal" className="site-footer">
         <div className="section-shell site-footer__inner">
-          <p>{copy.footer.companyLine}</p>
+          <div>
+            <p>{copy.footer.companyLine}</p>
+            <p style={{ marginTop: 6, fontSize: "0.82rem", color: "var(--text-secondary)" }}>
+              {copy.expansion.locations.map((loc, i) => (
+                <span key={loc.name}>
+                  {loc.name}
+                  {i < copy.expansion.locations.length - 1 ? " · " : ""}
+                </span>
+              ))}
+            </p>
+          </div>
           <div className="site-footer__links">
             <a href="#legal">{copy.footer.privacy}</a>
             <a href="#legal">{copy.footer.biometricData}</a>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -536,6 +536,37 @@ function App() {
         </motion.section>
 
         <motion.section
+          id="ethics"
+          className="section"
+          initial={{ opacity: 0, y: 24 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 0.2 }}
+          transition={{ duration: 0.65, ease: "easeOut" }}
+        >
+          <div className="section-shell">
+            <div className="section-copy">
+              <p className="section-kicker">07</p>
+              <h2>{copy.ethics.sectionTitle}</h2>
+            </div>
+
+            <div className="ethics-grid">
+              {copy.ethics.principles.map((principle) => (
+                <article key={principle.title} className="content-card ethics-card">
+                  <div className="ethics-card__icon" aria-hidden="true">&#x25C6;</div>
+                  <h3>{principle.title}</h3>
+                  <p>{principle.body}</p>
+                </article>
+              ))}
+            </div>
+
+            <div className="ethics-seal">
+              <span className="ethics-seal__mark" aria-hidden="true">&#x2726;</span>
+              <p>{copy.ethics.seal}</p>
+            </div>
+          </div>
+        </motion.section>
+
+        <motion.section
           id="about"
           className="section"
           initial={{ opacity: 0, y: 24 }}
@@ -545,7 +576,7 @@ function App() {
         >
           <div className="section-shell cta-grid">
             <div className="section-copy">
-              <p className="section-kicker">07</p>
+              <p className="section-kicker">08</p>
               <h2>{copy.finalCta.title}</h2>
               <div className="hero-actions">
                 <a className="button button--primary" href="#demo">
@@ -578,7 +609,7 @@ function App() {
         >
           <div className="section-shell demo-grid">
             <div className="section-copy">
-              <p className="section-kicker">08</p>
+              <p className="section-kicker">09</p>
               <h2>{copy.demoForm.title}</h2>
               <p>{copy.demoForm.support}</p>
             </div>

--- a/src/components/PauFloatingGuide.tsx
+++ b/src/components/PauFloatingGuide.tsx
@@ -156,11 +156,11 @@ export function PauFloatingGuide({ locale }: PauFloatingGuideProps) {
                     key={particle.id}
                     className="pau-guide-particle"
                     style={{
-                      ["--angle" as const]: `${particle.angle}deg`,
-                      ["--distance" as const]: `${particle.distance}px`,
-                      ["--delay" as const]: `${particle.delay}s`,
-                      ["--duration" as const]: `${particle.duration}s`,
-                    }}
+                      "--angle": `${particle.angle}deg`,
+                      "--distance": `${particle.distance}px`,
+                      "--delay": `${particle.delay}s`,
+                      "--duration": `${particle.duration}s`,
+                    } as React.CSSProperties}
                   />
                 ))}
               </div>

--- a/src/lib/treasuryClient.ts
+++ b/src/lib/treasuryClient.ts
@@ -1,0 +1,104 @@
+/**
+ * Treasury & Territory API client — V11 Expansion.
+ * Payout monitoring, capital blindaje and multi-node licensing.
+ *
+ * SIRET 94361019600017 | PCT/EP2025/067317
+ */
+
+export type TreasuryStatus = {
+  entity: string;
+  siret: string;
+  capital_eur: number;
+  total_payouts_eur: number;
+  reserve_eur: number;
+  payout_budget_eur: number;
+  payout_slots: number;
+  payout_amount_per_slot_eur: number;
+  payouts_executed: number;
+  capital_label: string;
+  bank: string;
+  ts: string;
+};
+
+export type PayoutEntry = {
+  amount_eur: number;
+  recipient: string;
+  concept: string;
+  ts: string;
+};
+
+export type TerritoryNode = {
+  id: string;
+  name: string;
+  city: string;
+  district: string;
+  status: "ACTIVE" | "PENDING_LICENCE";
+  licence_eur: number;
+  confirmed: boolean;
+};
+
+export type TerritorySummary = {
+  total_nodes: number;
+  active_nodes: number;
+  pending_nodes: number;
+  active_names: string[];
+  pending_names: string[];
+  confirmed_revenue_eur: number;
+  pending_revenue_eur: number;
+  expansion_target_eur: number;
+  licence_fee_eur: number;
+};
+
+export type NodeContract = {
+  ref: string;
+  node_id: string;
+  node_name: string;
+  total_licence_eur: number;
+  status: string;
+};
+
+export async function fetchTreasuryStatus(): Promise<TreasuryStatus | null> {
+  try {
+    const r = await fetch("/api/v1/treasury/status");
+    if (!r.ok) return null;
+    const j = (await r.json()) as TreasuryStatus & { status: string };
+    return j.status === "ok" ? j : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchTerritoryNodes(): Promise<{
+  nodes: TerritoryNode[];
+  summary: TerritorySummary;
+} | null> {
+  try {
+    const r = await fetch("/api/v1/territory/nodes");
+    if (!r.ok) return null;
+    const j = (await r.json()) as {
+      status: string;
+      nodes: TerritoryNode[];
+      summary: TerritorySummary;
+    };
+    return j.status === "ok" ? { nodes: j.nodes, summary: j.summary } : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function generateNodeContract(
+  nodeId: string,
+): Promise<NodeContract | null> {
+  try {
+    const r = await fetch("/api/v1/territory/contracts", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ node_id: nodeId }),
+    });
+    if (!r.ok) return null;
+    const j = (await r.json()) as { status: string; contract: NodeContract };
+    return j.status === "ok" ? j.contract : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/locales/salesCopy.ts
+++ b/src/locales/salesCopy.ts
@@ -102,6 +102,18 @@ export type SalesCopy = {
     cookies: string;
     security: string;
   };
+  expansion: {
+    sectionTitle: string;
+    activeBadge: string;
+    pendingBadge: string;
+    bannerTitle: string;
+    bannerBody: string;
+    locations: readonly {
+      name: string;
+      district: string;
+      status: "active" | "pending";
+    }[];
+  };
   overlayReserve: string;
   overlayCombos: string;
   overlayMuseum: string;
@@ -237,6 +249,19 @@ export const SALES_COPY: Record<AppLocale, SalesCopy> = {
       successBody: "Votre demande de démo a bien été envoyée. Notre équipe vous contactera rapidement.",
       error: "Impossible d'envoyer la demande pour le moment.",
       retry: "Veuillez réessayer dans quelques instants.",
+    },
+    expansion: {
+      sectionTitle: "Réseau d'implantation",
+      activeBadge: "Actif",
+      pendingBadge: "Prochaine ouverture",
+      bannerTitle: "Expansion en cours",
+      bannerBody: "De nouveaux points d'expérience ouvrent leurs portes. Le réseau souverain s'étend à travers Paris.",
+      locations: [
+        { name: "Galeries Lafayette Haussmann", district: "75009", status: "active" },
+        { name: "Le Bon Marché", district: "75007", status: "pending" },
+        { name: "Le Marais", district: "75003", status: "pending" },
+        { name: "La Défense", district: "92060", status: "pending" },
+      ],
     },
     footer: {
       companyLine: "Divineo · SIRET 94361019600017 · Paris, France",
@@ -380,6 +405,19 @@ export const SALES_COPY: Record<AppLocale, SalesCopy> = {
       error: "We could not send your request right now.",
       retry: "Please try again in a few moments.",
     },
+    expansion: {
+      sectionTitle: "Deployment network",
+      activeBadge: "Active",
+      pendingBadge: "Coming soon",
+      bannerTitle: "Expansion underway",
+      bannerBody: "New experience points are opening their doors. The sovereign network is expanding across Paris.",
+      locations: [
+        { name: "Galeries Lafayette Haussmann", district: "75009", status: "active" },
+        { name: "Le Bon Marché", district: "75007", status: "pending" },
+        { name: "Le Marais", district: "75003", status: "pending" },
+        { name: "La Défense", district: "92060", status: "pending" },
+      ],
+    },
     footer: {
       companyLine: "Divineo · SIRET 94361019600017 · Paris, France",
       privacy: "Privacy",
@@ -521,6 +559,19 @@ export const SALES_COPY: Record<AppLocale, SalesCopy> = {
       successBody: "Su solicitud de demo ha sido enviada. Nuestro equipo le contactará pronto.",
       error: "No hemos podido enviar su solicitud en este momento.",
       retry: "Por favor, inténtelo de nuevo en unos instantes.",
+    },
+    expansion: {
+      sectionTitle: "Red de implantación",
+      activeBadge: "Activo",
+      pendingBadge: "Próxima apertura",
+      bannerTitle: "Expansión en curso",
+      bannerBody: "Nuevos puntos de experiencia abren sus puertas. La red soberana se extiende por París.",
+      locations: [
+        { name: "Galeries Lafayette Haussmann", district: "75009", status: "active" },
+        { name: "Le Bon Marché", district: "75007", status: "pending" },
+        { name: "Le Marais", district: "75003", status: "pending" },
+        { name: "La Défense", district: "92060", status: "pending" },
+      ],
     },
     footer: {
       companyLine: "Divineo · SIRET 94361019600017 · París, Francia",

--- a/src/locales/salesCopy.ts
+++ b/src/locales/salesCopy.ts
@@ -114,6 +114,14 @@ export type SalesCopy = {
       status: "active" | "pending";
     }[];
   };
+  ethics: {
+    sectionTitle: string;
+    principles: readonly {
+      title: string;
+      body: string;
+    }[];
+    seal: string;
+  };
   overlayReserve: string;
   overlayCombos: string;
   overlayMuseum: string;
@@ -262,6 +270,28 @@ export const SALES_COPY: Record<AppLocale, SalesCopy> = {
         { name: "Le Marais", district: "75003", status: "pending" },
         { name: "La Défense", district: "92060", status: "pending" },
       ],
+    },
+    ethics: {
+      sectionTitle: "Manifeste éthique",
+      principles: [
+        {
+          title: "Protection biométrique",
+          body: "Les données corporelles ne quittent jamais l'appareil du client. Aucun stockage de silhouettes, aucune exploitation tierce.",
+        },
+        {
+          title: "Transparence algorithmique",
+          body: "Chaque recommandation de taille est traçable. Le client comprend pourquoi un ajustement lui est proposé.",
+        },
+        {
+          title: "Dignité du corps",
+          body: "Zéro commentaire sur le poids, zéro projection normative. Le moteur ajuste le vêtement au corps, jamais l'inverse.",
+        },
+        {
+          title: "Souveraineté des données",
+          body: "Le détaillant reçoit des signaux d'ajustement, jamais les données biométriques brutes. Le client reste propriétaire.",
+        },
+      ],
+      seal: "Manifeste Éthique V11 — Protocole de Souveraineté",
     },
     footer: {
       companyLine: "Divineo · SIRET 94361019600017 · Paris, France",
@@ -418,6 +448,28 @@ export const SALES_COPY: Record<AppLocale, SalesCopy> = {
         { name: "La Défense", district: "92060", status: "pending" },
       ],
     },
+    ethics: {
+      sectionTitle: "Ethical manifesto",
+      principles: [
+        {
+          title: "Biometric protection",
+          body: "Body data never leaves the customer's device. No silhouette storage, no third-party exploitation.",
+        },
+        {
+          title: "Algorithmic transparency",
+          body: "Every size recommendation is traceable. The customer understands why a fit adjustment is suggested.",
+        },
+        {
+          title: "Body dignity",
+          body: "Zero weight commentary, zero normative projection. The engine fits the garment to the body, never the other way round.",
+        },
+        {
+          title: "Data sovereignty",
+          body: "The retailer receives fit signals, never raw biometric data. The customer remains the owner.",
+        },
+      ],
+      seal: "Ethical Manifesto V11 — Sovereignty Protocol",
+    },
     footer: {
       companyLine: "Divineo · SIRET 94361019600017 · Paris, France",
       privacy: "Privacy",
@@ -572,6 +624,28 @@ export const SALES_COPY: Record<AppLocale, SalesCopy> = {
         { name: "Le Marais", district: "75003", status: "pending" },
         { name: "La Défense", district: "92060", status: "pending" },
       ],
+    },
+    ethics: {
+      sectionTitle: "Manifiesto ético",
+      principles: [
+        {
+          title: "Protección biométrica",
+          body: "Los datos corporales nunca salen del dispositivo del cliente. Sin almacenamiento de siluetas, sin explotación por terceros.",
+        },
+        {
+          title: "Transparencia algorítmica",
+          body: "Cada recomendación de talla es trazable. El cliente entiende por qué se le sugiere un ajuste.",
+        },
+        {
+          title: "Dignidad del cuerpo",
+          body: "Cero comentarios sobre peso, cero proyección normativa. El motor ajusta la prenda al cuerpo, nunca al revés.",
+        },
+        {
+          title: "Soberanía de los datos",
+          body: "El retailer recibe señales de ajuste, nunca datos biométricos brutos. El cliente sigue siendo el propietario.",
+        },
+      ],
+      seal: "Manifiesto Ético V11 — Protocolo de Soberanía",
     },
     footer: {
       companyLine: "Divineo · SIRET 94361019600017 · París, Francia",

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,7 @@
   "public": true,
   "installCommand": "npm install && pip install -r requirements.txt",
   "cleanUrls": true,
+  "regions": ["cdg1", "lhr1"],
   "env": {
     "TRYONYOU_PUBLIC_DOMAIN": "tryonyou.app"
   },
@@ -16,11 +17,17 @@
     },
     {
       "src": "api/index.py",
-      "use": "@vercel/python"
+      "use": "@vercel/python",
+      "config": {
+        "maxDuration": 30
+      }
     },
     {
       "src": "api/vetos_core_inference.py",
-      "use": "@vercel/python"
+      "use": "@vercel/python",
+      "config": {
+        "maxDuration": 60
+      }
     }
   ],
   "routes": [
@@ -49,6 +56,15 @@
     }
   ],
   "headers": [
+    {
+      "source": "/assets/:path*",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
     {
       "source": "/docs/:path*",
       "headers": [
@@ -103,7 +119,7 @@
         },
         {
           "key": "X-TryOnYou-Access-Policy",
-          "value": "sovereign-firebase-align-2026-04-07"
+          "value": "sovereign-v11-sanitized-2026-04-14"
         }
       ]
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Complete financial sanitization, multi-node territory expansion infrastructure, and ethical manifesto seal for TryOnYou V11 — Sovereignty Protocol.

---

### Vercel Production Hardening
- **Regions**: Deployed to `cdg1` (Paris) and `lhr1` (London) for EU-first latency
- **Serverless scaling**: `maxDuration` 30s for main API, 60s for vetos inference
- **Static asset caching**: Immutable cache headers (`max-age=31536000`) for `/assets/*`
- **Access policy**: Updated to `sovereign-v11-sanitized-2026-04-14`

### Treasury API — Capital Blindaje
- `GET /api/v1/treasury/status` — Full treasury snapshot: capital (398,744.50 EUR), payout budget, reserve, Qonto Business bank
- `GET /api/v1/treasury/payouts` — Payout history log
- `POST /api/v1/treasury/payouts` — Record outbound payout (decrements reserve)
- Capital reserve correctly tracks outbound movements while shielding sovereign reserve

### Territory Expansion API — Multi-Node Licensing
- `GET /api/v1/territory/nodes` — All 4 expansion nodes with licensing status + summary
- `POST /api/v1/territory/contracts` — Generate proforma contract per node (CTR-YYYYMMDD-NNN)
- **Active node**: Galeries Lafayette Haussmann (75009)
- **Pending nodes**: Le Bon Marché (75007), Le Marais (75003), La Défense (92060)
- Standard V11 licence: 27,500 EUR (12,500 setup + 15,000 exclusivity)

### Health Endpoint Enrichment
- Version bumped to `V11.1_Expansion_Sovereign`
- Now reports `territory_active_nodes`, `territory_pending_nodes`, `territory_expansion_target_eur` (110,000 EUR)
- Reports `treasury_reserve_eur` and `treasury_capital_label`

### Frontend — Expansion Section
- New section "Réseau d'implantation" / "Deployment network" with 4 location cards
- "Expansion en cours" / "Expansion underway" gold banner
- Active/Pending badges with pulse animation on pending nodes
- All 4 locations listed in footer

### Frontend — Ethical Manifesto Section
- 4 principles: Biometric protection, Algorithmic transparency, Body dignity, Data sovereignty
- Gold seal: "Manifeste Éthique V11 — Protocole de Souveraineté"
- Full trilingual support (FR/EN/ES)

### SEO — Schema.org JSON-LD
- Dynamic `Organization` structured data with `taxID`, `founder`, `ethicsPolicy`, `knowsAbout`

### Code Quality
- TypeScript: 0 errors
- Vite production build: 0 errors, 0 warnings
- Python tests: 293/293 passing
- Fix pre-existing `PauFloatingGuide.tsx` CSS custom property TS error

---

### Evidence

**Expansion section (English):**

[Deployment network section](https://cursor.com/agents/bc-e7994812-a8ab-5f23-99e0-67415c3274d1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexpansion_section_deployment_network.webp)

**Ethical manifesto section (English):**

[Ethical manifesto section](https://cursor.com/agents/bc-e7994812-a8ab-5f23-99e0-67415c3274d1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fethics_manifesto_section.webp)

**Full walkthrough video — expansion + ethics sections in FR/EN:**

[expansion_and_ethics_walkthrough.mp4](https://cursor.com/agents/bc-e7994812-a8ab-5f23-99e0-67415c3274d1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexpansion_and_ethics_walkthrough.mp4)

---

SIRET 94361019600017 | PCT/EP2025/067317
Bajo Protocolo de Soberanía V10 - Founder: Rubén

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://tryonyou.slack.com/archives/D0AP1MQ3517/p1776001179723309?thread_ts=1776001179.723309&cid=D0AP1MQ3517)

<div><a href="https://cursor.com/agents/bc-e7994812-a8ab-5f23-99e0-67415c3274d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7994812-a8ab-5f23-99e0-67415c3274d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

