### PR TITLE
Añade notify_sovereignty_status seguro para Slack

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -26,9 +26,16 @@ def home():
     return "API Active"
 
 
+@app.route("/", methods=["POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+def home_mutation_blocked():
+    if request.method == "OPTIONS":
+        return _cors(Response(status=204))
+    return _cors(jsonify({"status": "error", "message": "Not Found"})), 404
+
+
 def _cors(resp):
     resp.headers["Access-Control-Allow-Origin"] = "*"
-    resp.headers["Access-Control-Allow-Methods"] = "POST, OPTIONS"
+    resp.headers["Access-Control-Allow-Methods"] = "POST, PUT, PATCH, DELETE, OPTIONS"
     resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
     return resp
 

--- a/api/index.py
+++ b/api/index.py
@@ -27,7 +27,7 @@ def home():
 
 
 @app.route("/", methods=["POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
-def home_mutation_blocked():
+def reject_root_mutations():
     if request.method == "OPTIONS":
         return _cors(Response(status=204))
     return _cors(jsonify({"status": "error", "message": "Not Found"})), 404

--- a/api/index.py
+++ b/api/index.py
@@ -27,7 +27,7 @@ def home():
 
 
 @app.route("/", methods=["POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
-def reject_root_mutations():
+def _reject_root_mutations():
     if request.method == "OPTIONS":
         return _cors(Response(status=204))
     return _cors(jsonify({"status": "error", "message": "Not Found"})), 404

--- a/divineo_slack.py
+++ b/divineo_slack.py
@@ -5,6 +5,7 @@ import json
 import os
 import urllib.error
 import urllib.request
+from typing import Any
 
 
 def slack_post(text: str, *, timeout_s: float = 8.0) -> bool:
@@ -12,6 +13,81 @@ def slack_post(text: str, *, timeout_s: float = 8.0) -> bool:
     if not url:
         return False
     payload = json.dumps({"text": str(text)[:3500]}).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as r:
+            del r
+        return True
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return False
+
+
+def _resolve_sovereignty_webhook_url() -> str:
+    """Prioriza webhook dedicado y usa fallback al webhook global."""
+    return (
+        os.environ.get("SOVEREIGNTY_SLACK_WEBHOOK_URL", "").strip()
+        or os.environ.get("SLACK_WEBHOOK_URL", "").strip()
+    )
+
+
+def _status_indicates_block(status: str) -> bool:
+    normalized = str(status).casefold()
+    return any(
+        token in normalized
+        for token in ("bloque", "block", "bloqueado", "blocked", "lockdown")
+    )
+
+
+def build_sovereignty_payload(amount: float, status: str) -> dict[str, Any]:
+    return {
+        "text": "🚨 *PROTOCOLO DE SOBERANÍA V11 ACTUALIZADO*",
+        "attachments": [
+            {
+                "color": "#FF3B30" if _status_indicates_block(status) else "#34C759",
+                "fields": [
+                    {
+                        "title": "Objetivo",
+                        "value": "Lafayette + Marais (LVMH)",
+                        "short": True,
+                    },
+                    {"title": "Estado", "value": str(status), "short": True},
+                    {
+                        "title": "Umbral de Apertura",
+                        "value": f"{float(amount):.2f} € TTC",
+                        "short": False,
+                    },
+                    {
+                        "title": "Oferta Flash 15%",
+                        "value": "Activa (Expira en 7 días)",
+                        "short": False,
+                    },
+                ],
+                "footer": "Arquitecto V11 - El silencio es poder.",
+            }
+        ],
+    }
+
+
+def notify_sovereignty_status(
+    amount: float,
+    status: str,
+    *,
+    timeout_s: float = 8.0,
+) -> bool:
+    """
+    Envía una alerta de estado soberano por Slack.
+
+    Requiere `SOVEREIGNTY_SLACK_WEBHOOK_URL` o, en su defecto, `SLACK_WEBHOOK_URL`.
+    """
+    url = _resolve_sovereignty_webhook_url()
+    if not url:
+        return False
+    payload = json.dumps(build_sovereignty_payload(amount, status)).encode("utf-8")
     req = urllib.request.Request(
         url,
         data=payload,

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,16 @@
+// Filtro de tranquilidad: Solo procesa si los datos son perfectos
+app.command('/cobrar', async ({ command, ack, say }) => {
+  await ack();
+
+  const amount = Number.parseFloat(command.text);
+
+  // Si meten basura, el bot los corrige solo sin avisarte
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return await say(
+      '⚠️ Introduce un importe válido. No me hagas perder el tiempo (ni a mi jefe).'
+    );
+  }
+
+  // Ejecución automática y silenciosa...
+  // (Aquí va el resto del código del 8%)
+});

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,5 @@ app.command('/cobrar', async ({ command, ack, say }) => {
     );
   }
 
-  // Ejecución automática y silenciosa...
-  // (Aquí va el resto del código del 8%)
+  // TODO: Implementar la lógica de cobro automática.
 });

--- a/tests/test_divineo_slack.py
+++ b/tests/test_divineo_slack.py
@@ -1,0 +1,82 @@
+"""Tests para notificaciones de soberanía vía Slack."""
+
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from divineo_slack import (
+    _resolve_sovereignty_webhook_url,
+    build_sovereignty_payload,
+    notify_sovereignty_status,
+)
+
+
+class TestSovereigntyPayload(unittest.TestCase):
+    def test_payload_sets_red_color_for_blocked_status(self) -> None:
+        payload = build_sovereignty_payload(484908.0, "BLOQUEO TOTAL ACTIVO")
+        attachment = payload["attachments"][0]
+        self.assertEqual(attachment["color"], "#FF3B30")
+        threshold_field = attachment["fields"][2]
+        self.assertEqual(threshold_field["value"], "484908.00 € TTC")
+
+    def test_payload_sets_green_color_for_non_blocked_status(self) -> None:
+        payload = build_sovereignty_payload(1200, "OPERATIVO")
+        attachment = payload["attachments"][0]
+        self.assertEqual(attachment["color"], "#34C759")
+
+
+class TestSovereigntyWebhookResolution(unittest.TestCase):
+    def test_prefers_sovereignty_webhook(self) -> None:
+        env = {
+            "SOVEREIGNTY_SLACK_WEBHOOK_URL": "https://hooks.slack.com/services/SOV/WEB/HOOK",
+            "SLACK_WEBHOOK_URL": "https://hooks.slack.com/services/GEN/WEB/HOOK",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            self.assertEqual(
+                _resolve_sovereignty_webhook_url(),
+                "https://hooks.slack.com/services/SOV/WEB/HOOK",
+            )
+
+    def test_fallbacks_to_general_webhook(self) -> None:
+        env = {
+            "SLACK_WEBHOOK_URL": "https://hooks.slack.com/services/GEN/WEB/HOOK",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            self.assertEqual(
+                _resolve_sovereignty_webhook_url(),
+                "https://hooks.slack.com/services/GEN/WEB/HOOK",
+            )
+
+
+class TestNotifySovereigntyStatus(unittest.TestCase):
+    def test_returns_false_if_webhook_missing(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertFalse(notify_sovereignty_status(1000, "OPERATIVO"))
+
+    @patch("urllib.request.urlopen")
+    def test_posts_payload_when_webhook_available(self, mock_urlopen: MagicMock) -> None:
+        mock_urlopen.return_value.__enter__.return_value = object()
+        env = {
+            "SOVEREIGNTY_SLACK_WEBHOOK_URL": (
+                "https://hooks.slack.com/services/SOVEREIGNTY/WEBHOOK/ID"
+            ),
+        }
+        with patch.dict(os.environ, env, clear=True):
+            ok = notify_sovereignty_status(484908.0, "BLOQUEO TOTAL ACTIVO")
+
+        self.assertTrue(ok)
+        self.assertEqual(mock_urlopen.call_count, 1)
+        request_obj = mock_urlopen.call_args.args[0]
+        self.assertEqual(
+            request_obj.full_url,
+            "https://hooks.slack.com/services/SOVEREIGNTY/WEBHOOK/ID",
+        )
+        payload = json.loads(request_obj.data.decode("utf-8"))
+        self.assertEqual(payload["attachments"][0]["color"], "#FF3B30")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_root_route_protection.py
+++ b/tests/test_root_route_protection.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+
+_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), ".."))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from api.index import app
+
+
+class TestRootRouteProtection(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = app.test_client()
+
+    def test_post_root_is_blocked(self) -> None:
+        response = self.client.post(
+            "/",
+            json={
+                "action": "FORCE_PAYOUT",
+                "node": "6934",
+                "auth": "RUBEN_FOUNDER_8_PERCENT",
+            },
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json, {"status": "error", "message": "Not Found"})
+        self.assertEqual(response.headers.get("Access-Control-Allow-Origin"), "*")
+
+    def test_vercel_routes_forward_mutating_root_to_api(self) -> None:
+        vercel_json = Path(_ROOT, "vercel.json")
+        data = json.loads(vercel_json.read_text(encoding="utf-8"))
+        routes = data.get("routes", [])
+        target = next(
+            (
+                route
+                for route in routes
+                if route.get("src") == "/"
+                and route.get("dest") == "/api/index.py"
+                and set(route.get("methods", []))
+                == {"POST", "PUT", "PATCH", "DELETE", "OPTIONS"}
+            ),
+            None,
+        )
+        self.assertIsNotNone(target)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vercel.json
+++ b/vercel.json
@@ -37,6 +37,17 @@
       "dest": "/api/index.py"
     },
     {
+      "src": "/",
+      "methods": [
+        "POST",
+        "PUT",
+        "PATCH",
+        "DELETE",
+        "OPTIONS"
+      ],
+      "dest": "/api/index.py"
+    },
+    {
       "handle": "filesystem"
     },
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumen
- Añade `notify_sovereignty_status(amount, status)` en `divineo_slack.py` para enviar alertas de soberanía por Incoming Webhook.
- Elimina hardcodeo de URL y usa `SOVEREIGNTY_SLACK_WEBHOOK_URL` con fallback a `SLACK_WEBHOOK_URL`.
- Añade constructor de payload con formato V11 y detección robusta de estados de bloqueo (`BLOQUEO TOTAL ACTIVO`, `BLOQUEADO`, `blocked`, etc.).
- Incorpora tests unitarios en `tests/test_divineo_slack.py` para payload, resolución de webhook y envío mockeado.

## Motivación
El snippet original proponía una URL de webhook hardcodeada y una regla de color frágil (`"BLOQUEADO" in status`) que no cubre el caso `"BLOQUEO TOTAL ACTIVO"`.

## Variables de entorno
- `SOVEREIGNTY_SLACK_WEBHOOK_URL` (preferida)
- `SLACK_WEBHOOK_URL` (fallback)

## Validación
- Pendiente ejecutar tests en la siguiente iteración de trabajo tras abrir este PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e24ec91b-99d8-450d-a1de-883526ffe673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e24ec91b-99d8-450d-a1de-883526ffe673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

