### PR TITLE
Resolver b1624497 con consolidación backend Divineo V11

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1,5 +1,7 @@
 import json
+import os
 import sys
+from urllib.parse import urlencode
 from pathlib import Path
 from typing import Any
 
@@ -31,6 +33,8 @@ from stripe_lafayette import create_lafayette_checkout  # noqa: E402
 from financial_guard import log_sovereignty_event  # noqa: E402
 
 app = Flask(__name__)
+ADVBET_PROVIDER = "ABVETOS_ADVBET"
+DEFAULT_BIOMETRIC_DEEP_LINK_BASE = "https://abvetos.com/identity/biometric-verify"
 
 
 def _cors(resp: Response) -> Response:
@@ -56,6 +60,33 @@ def _read_json_body() -> dict[str, Any]:
         return body if isinstance(body, dict) else {}
     body = request.get_json(force=True, silent=True) or {}
     return body if isinstance(body, dict) else {}
+
+
+def _build_advbet_biometric_deep_link(session_id: str) -> str:
+    base = (
+        os.getenv("ADVBET_BIOMETRIC_DEEP_LINK_BASE")
+        or os.getenv("BIOMETRIC_DEEP_LINK_BASE")
+        or DEFAULT_BIOMETRIC_DEEP_LINK_BASE
+    ).strip()
+    if not base:
+        base = DEFAULT_BIOMETRIC_DEEP_LINK_BASE
+    query = urlencode(
+        {
+            "session_id": session_id,
+            "provider": ADVBET_PROVIDER.lower(),
+            "verification": "voice_facial",
+        }
+    )
+    return f"{base}?{query}"
+
+
+def _build_advbet_qr_payload(session_id: str, deep_link: str) -> dict[str, str]:
+    suffix = session_id[-8:].upper() if session_id else "SESSION"
+    return {
+        "format": "deep_link",
+        "qr_token": f"ADVBET-{suffix}",
+        "deep_link": deep_link,
+    }
 
 
 def _handshake_payload() -> dict[str, Any]:
@@ -215,8 +246,26 @@ def empire_payment_intent() -> tuple[Response, int]:
         return _json_response(
             {"status": "error", "message": "payment_intent_creation_failed"}, 502
         )
+    deep_link = _build_advbet_biometric_deep_link(session_id)
+    qr_payload = _build_advbet_qr_payload(session_id, deep_link)
+    log_sovereignty_event(
+        event_type="empire_payment_intent_created",
+        detail=f"provider={ADVBET_PROVIDER} deep_link_ready=true",
+        session_id=session_id,
+        amount_eur=amount_eur,
+    )
     return _json_response(
-        {"status": "ok", "client_secret": client_secret, "session_id": session_id}, 200
+        {
+            "status": "ok",
+            "client_secret": client_secret,
+            "session_id": session_id,
+            "advbet": {
+                "provider": ADVBET_PROVIDER,
+                "biometric_deep_link": deep_link,
+                "qr_payload": qr_payload,
+            },
+        },
+        200,
     )
 
 

--- a/api/stripe_webhook_fr.py
+++ b/api/stripe_webhook_fr.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import urllib.parse
 import urllib.request
 from pathlib import Path
 
@@ -26,13 +27,69 @@ import stripe
 from financial_guard import log_sovereignty_event
 from stripe_fr_resolve import resolve_stripe_secret_fr, resolve_stripe_webhook_secret_fr
 
+SUCCESS_PAYMENT_STATUSES = frozenset({"paid", "success", "succeeded", "payment_success"})
+
+
+def _is_payment_success(payment_status: str) -> bool:
+    return payment_status.strip().lower() in SUCCESS_PAYMENT_STATUSES
+
+
+def _notify_hito2_blindado(
+    session_id: str,
+    payment_status: str,
+    amount_eur: float,
+) -> None:
+    webhook_url = (
+        os.getenv("JULES_SLACK_WEBHOOK_URL")
+        or os.getenv("SLACK_WEBHOOK_URL")
+        or os.getenv("MAKE_WEBHOOK_URL")
+        or ""
+    ).strip()
+    if not webhook_url:
+        log_sovereignty_event(
+            event_type="hito2_notify_skipped",
+            detail="no_webhook_configured",
+            session_id=session_id,
+            amount_eur=amount_eur,
+        )
+        return
+    payload = {
+        "event": "hito2_blindado",
+        "status": "RESOLVED",
+        "session_id": session_id,
+        "payment_status": payment_status,
+        "amount_eur": amount_eur,
+        "message": "Hito 2: Blindado",
+    }
+    try:
+        req = urllib.request.Request(
+            webhook_url,
+            data=json.dumps(payload).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        urllib.request.urlopen(req, timeout=8)
+        log_sovereignty_event(
+            event_type="hito2_notified",
+            detail="channel=slack_or_make",
+            session_id=session_id,
+            amount_eur=amount_eur,
+        )
+    except Exception as exc:
+        log_sovereignty_event(
+            event_type="hito2_notify_error",
+            detail=str(exc)[:300],
+            session_id=session_id,
+            amount_eur=amount_eur,
+        )
+
 
 def _persist_sovereignty_state(
     session_id: str,
     payment_status: str,
     amount_eur: float,
     metadata: dict,
-) -> None:
+) -> bool:
     """Persist SOUVERAINETÉ : 1 to Supabase after confirmed payment."""
     supabase_url = os.getenv("SUPABASE_URL", "")
     supabase_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "")
@@ -42,17 +99,34 @@ def _persist_sovereignty_state(
             detail="supabase_not_configured",
             session_id=session_id,
         )
-        return
+        return False
+    users_table = (os.getenv("CORE_ENGINE_USERS_TABLE") or "users").strip() or "users"
+    events_table = (os.getenv("CORE_ENGINE_EVENTS_TABLE") or "core_engine_events").strip() or "core_engine_events"
     try:
+        status_patch = {"status": "SOUVERAINETÉ:1"}
+        session_filter = urllib.parse.quote(session_id, safe="")
+        patch_req = urllib.request.Request(
+            f"{supabase_url}/rest/v1/{users_table}?session_id=eq.{session_filter}",
+            data=json.dumps(status_patch).encode(),
+            headers={
+                "apikey": supabase_key,
+                "Authorization": f"Bearer {supabase_key}",
+                "Content-Type": "application/json",
+                "Prefer": "return=minimal",
+            },
+            method="PATCH",
+        )
+        urllib.request.urlopen(patch_req, timeout=8)
         row = {
             "session_id": session_id,
+            "event_type": "payment_success",
             "payment_status": payment_status,
             "amount_eur": amount_eur,
             "sovereignty_level": 1,
             "metadata": json.dumps(metadata),
         }
-        req = urllib.request.Request(
-            f"{supabase_url}/rest/v1/core_engine_events",
+        event_req = urllib.request.Request(
+            f"{supabase_url}/rest/v1/{events_table}",
             data=json.dumps(row).encode(),
             headers={
                 "apikey": supabase_key,
@@ -62,19 +136,21 @@ def _persist_sovereignty_state(
             },
             method="POST",
         )
-        urllib.request.urlopen(req, timeout=8)
+        urllib.request.urlopen(event_req, timeout=8)
         log_sovereignty_event(
             event_type="sovereignty_persisted",
-            detail=f"level=1 status={payment_status}",
+            detail=f"users_status_updated:SOUVERAINETÉ:1 status={payment_status}",
             session_id=session_id,
             amount_eur=amount_eur,
         )
+        return True
     except Exception as exc:
         log_sovereignty_event(
             event_type="sovereignty_persist_error",
             detail=str(exc)[:300],
             session_id=session_id,
         )
+        return False
 
 
 def process_stripe_webhook_event(event: dict) -> None:
@@ -95,24 +171,54 @@ def process_stripe_webhook_event(event: dict) -> None:
             amount_eur=amount_total / 100.0 if amount_total else 0.0,
         )
 
-        _persist_sovereignty_state(
-            session_id=session_id,
-            payment_status=payment_status,
-            amount_eur=amount_total / 100.0 if amount_total else 0.0,
-            metadata=metadata,
-        )
+        if _is_payment_success(payment_status):
+            amount_eur = amount_total / 100.0 if amount_total else 0.0
+            persisted = _persist_sovereignty_state(
+                session_id=session_id,
+                payment_status=payment_status,
+                amount_eur=amount_eur,
+                metadata=metadata,
+            )
+            if persisted:
+                _notify_hito2_blindado(
+                    session_id=session_id,
+                    payment_status=payment_status,
+                    amount_eur=amount_eur,
+                )
+        else:
+            log_sovereignty_event(
+                event_type="sovereignty_persist_skipped",
+                detail=f"payment_not_success:{payment_status}",
+                session_id=session_id,
+                amount_eur=amount_total / 100.0 if amount_total else 0.0,
+            )
 
     elif etype == "payment_intent.succeeded":
         intent_id = data.get("id", "")
         amount = data.get("amount", 0)
         currency = data.get("currency", "eur")
+        metadata = data.get("metadata") or {}
+        session_id = str(metadata.get("session_id") or intent_id or "")
+        amount_eur = amount / 100.0 if amount else 0.0
 
         log_sovereignty_event(
             event_type="payment_intent_succeeded",
             detail=f"intent={intent_id} amount={amount} currency={currency}",
-            session_id=intent_id,
-            amount_eur=amount / 100.0 if amount else 0.0,
+            session_id=session_id,
+            amount_eur=amount_eur,
         )
+        persisted = _persist_sovereignty_state(
+            session_id=session_id,
+            payment_status="succeeded",
+            amount_eur=amount_eur,
+            metadata=metadata,
+        )
+        if persisted:
+            _notify_hito2_blindado(
+                session_id=session_id,
+                payment_status="succeeded",
+                amount_eur=amount_eur,
+            )
 
 
 def handle_stripe_webhook_fr(raw_body: bytes, sig_header: str | None) -> tuple[dict, int]:

--- a/tests/test_empire_payment_intent_v11.py
+++ b/tests/test_empire_payment_intent_v11.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), ".."))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from api.index import ADVBET_PROVIDER, app
+
+
+class TestEmpirePaymentIntentV11(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = app.test_client()
+        os.environ.pop("ADVBET_BIOMETRIC_DEEP_LINK_BASE", None)
+        os.environ.pop("BIOMETRIC_DEEP_LINK_BASE", None)
+
+    def test_requires_session_and_amount(self) -> None:
+        response = self.client.post("/api/v1/empire/payment-intent", json={"session_id": ""})
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json["status"], "error")
+
+    def test_returns_advbet_deep_link_and_qr_payload(self) -> None:
+        with patch("api.index.create_lafayette_checkout", return_value="pi_secret_123"):
+            response = self.client.post(
+                "/api/v1/empire/payment-intent",
+                json={"session_id": "sess_abc_1234", "amount_eur": 125.0},
+            )
+        self.assertEqual(response.status_code, 200)
+        body = response.json
+        self.assertEqual(body["status"], "ok")
+        self.assertEqual(body["client_secret"], "pi_secret_123")
+        self.assertEqual(body["advbet"]["provider"], ADVBET_PROVIDER)
+        self.assertIn("session_id=sess_abc_1234", body["advbet"]["biometric_deep_link"])
+        self.assertEqual(body["advbet"]["qr_payload"]["format"], "deep_link")
+        self.assertEqual(
+            body["advbet"]["qr_payload"]["deep_link"],
+            body["advbet"]["biometric_deep_link"],
+        )
+
+    def test_uses_env_deep_link_base_when_present(self) -> None:
+        os.environ["ADVBET_BIOMETRIC_DEEP_LINK_BASE"] = "https://verify.example.com/bio"
+        with patch("api.index.create_lafayette_checkout", return_value="pi_secret_abc"):
+            response = self.client.post(
+                "/api/v1/empire/payment-intent",
+                json={"session_id": "sess_live_9999", "amount_eur": 80},
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            response.json["advbet"]["biometric_deep_link"].startswith("https://verify.example.com/bio?")
+        )
+
+    def test_returns_502_when_payment_intent_fails(self) -> None:
+        with patch("api.index.create_lafayette_checkout", return_value=None):
+            response = self.client.post(
+                "/api/v1/empire/payment-intent",
+                json={"session_id": "sess_err_1001", "amount_eur": 50},
+            )
+        self.assertEqual(response.status_code, 502)
+        self.assertEqual(response.json["message"], "payment_intent_creation_failed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stripe_webhook_fr_v11.py
+++ b/tests/test_stripe_webhook_fr_v11.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), ".."))
+_API = os.path.join(_ROOT, "api")
+for _p in (_ROOT, _API):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from stripe_webhook_fr import process_stripe_webhook_event
+
+
+class TestStripeWebhookFrV11(unittest.TestCase):
+    def test_checkout_completed_paid_persists_and_notifies(self) -> None:
+        event = {
+            "type": "checkout.session.completed",
+            "data": {
+                "object": {
+                    "id": "sess_paid_001",
+                    "payment_status": "paid",
+                    "amount_total": 1250000,
+                    "metadata": {"session_id": "sess_paid_001"},
+                }
+            },
+        }
+        with (
+            patch("stripe_webhook_fr._persist_sovereignty_state", return_value=True) as persist,
+            patch("stripe_webhook_fr._notify_hito2_blindado") as notify,
+        ):
+            process_stripe_webhook_event(event)
+        persist.assert_called_once()
+        notify.assert_called_once_with(
+            session_id="sess_paid_001",
+            payment_status="paid",
+            amount_eur=12500.0,
+        )
+
+    def test_checkout_completed_unpaid_skips_persist(self) -> None:
+        event = {
+            "type": "checkout.session.completed",
+            "data": {
+                "object": {
+                    "id": "sess_open_001",
+                    "payment_status": "open",
+                    "amount_total": 1000,
+                    "metadata": {},
+                }
+            },
+        }
+        with (
+            patch("stripe_webhook_fr._persist_sovereignty_state") as persist,
+            patch("stripe_webhook_fr._notify_hito2_blindado") as notify,
+        ):
+            process_stripe_webhook_event(event)
+        persist.assert_not_called()
+        notify.assert_not_called()
+
+    def test_payment_intent_succeeded_uses_metadata_session_id(self) -> None:
+        event = {
+            "type": "payment_intent.succeeded",
+            "data": {
+                "object": {
+                    "id": "pi_001",
+                    "amount": 9900,
+                    "currency": "eur",
+                    "metadata": {"session_id": "sess_pi_001"},
+                }
+            },
+        }
+        with (
+            patch("stripe_webhook_fr._persist_sovereignty_state", return_value=True) as persist,
+            patch("stripe_webhook_fr._notify_hito2_blindado") as notify,
+        ):
+            process_stripe_webhook_event(event)
+        persist.assert_called_once_with(
+            session_id="sess_pi_001",
+            payment_status="succeeded",
+            amount_eur=99.0,
+            metadata={"session_id": "sess_pi_001"},
+        )
+        notify.assert_called_once_with(
+            session_id="sess_pi_001",
+            payment_status="succeeded",
+            amount_eur=99.0,
+        )
+
+
+class TestPersistSovereigntyStateV11(unittest.TestCase):
+    def setUp(self) -> None:
+        self._saved = {
+            "SUPABASE_URL": os.environ.get("SUPABASE_URL"),
+            "SUPABASE_SERVICE_ROLE_KEY": os.environ.get("SUPABASE_SERVICE_ROLE_KEY"),
+            "CORE_ENGINE_USERS_TABLE": os.environ.get("CORE_ENGINE_USERS_TABLE"),
+            "CORE_ENGINE_EVENTS_TABLE": os.environ.get("CORE_ENGINE_EVENTS_TABLE"),
+        }
+        os.environ["SUPABASE_URL"] = "https://example.supabase.co"
+        os.environ["SUPABASE_SERVICE_ROLE_KEY"] = "service-role-key"
+        os.environ["CORE_ENGINE_USERS_TABLE"] = "users"
+        os.environ["CORE_ENGINE_EVENTS_TABLE"] = "core_engine_events"
+
+    def tearDown(self) -> None:
+        for key, value in self._saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    def test_persist_updates_users_status_and_inserts_event(self) -> None:
+        from stripe_webhook_fr import _persist_sovereignty_state
+
+        calls: list[str] = []
+
+        def _fake_urlopen(req, timeout=0):  # noqa: ANN001
+            calls.append(f"{req.method} {req.full_url}")
+            return object()
+
+        with patch("stripe_webhook_fr.urllib.request.urlopen", side_effect=_fake_urlopen):
+            ok = _persist_sovereignty_state(
+                session_id="sess_42",
+                payment_status="paid",
+                amount_eur=12500.0,
+                metadata={"a": 1},
+            )
+
+        self.assertTrue(ok)
+        self.assertEqual(len(calls), 2)
+        self.assertIn("PATCH https://example.supabase.co/rest/v1/users?session_id=eq.sess_42", calls[0])
+        self.assertIn("POST https://example.supabase.co/rest/v1/core_engine_events", calls[1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objetivo
Resolver la tarea `b1624497-930b-457f-ba90-c5dbd0d93829` bajo protocolo de consolidación V11, cubriendo dependencias backend, endpoint SNAP biométrico y persistencia soberana post-pago.

## Cambios realizados
- En `api/index.py`:
  - Se extiende `/api/v1/empire/payment-intent` para devolver payload `advbet` con:
    - `provider` (`ABVETOS_ADVBET`)
    - `biometric_deep_link` (configurable por `ADVBET_BIOMETRIC_DEEP_LINK_BASE`)
    - `qr_payload` con token y deep link.
  - Se deja trazabilidad de eventos en `financial_guard` para solicitud/creación de intent.
- En `api/stripe_webhook_fr.py`:
  - Se aplica persistencia condicional solo cuando el pago es exitoso.
  - Se implementa actualización de Supabase en `users` por `session_id` con `status='SOUVERAINETÉ:1'`.
  - Se mantiene registro en `core_engine_events` con `event_type=payment_success`.
  - Se añade notificación “Hito 2: Blindado” a webhook configurable (`JULES_SLACK_WEBHOOK_URL`/`SLACK_WEBHOOK_URL`/`MAKE_WEBHOOK_URL`) cuando la persistencia es correcta.
- Nuevos tests:
  - `tests/test_empire_payment_intent_v11.py`
  - `tests/test_stripe_webhook_fr_v11.py`

## Validación de consolidación V11
Se ejecutó validación cruzada de `master_omega_vault.json` y `production_manifest.json` contra entorno (sin exponer secretos).

Resultado: 6/7 checks OK y 1 discrepancia por variables faltantes en entorno para ejecución productiva del flujo Stripe/Supabase/Advbet.

## Pruebas ejecutadas
- `python3 -m unittest tests.test_empire_payment_intent_v11 tests.test_stripe_webhook_fr_v11 -v`
- `python3 -m unittest tests.test_root_route_protection tests.test_stripe_lafayette -v`
- `python3 -m py_compile api/index.py api/stripe_webhook_fr.py tests/test_empire_payment_intent_v11.py tests/test_stripe_webhook_fr_v11.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a7f73f7-3a9e-4528-859d-068f1094f023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a7f73f7-3a9e-4528-859d-068f1094f023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

