### PR TITLE
feat: Divineo Global Orchestrator — Moda × Tecnología × Negocio (Pegaso V9.2.6)

### DIFF
--- a/api/divineo_global_orchestrator.py
+++ b/api/divineo_global_orchestrator.py
@@ -1,0 +1,169 @@
+"""Divineo Global Orchestrator — Moda x Tecnología x Negocio.
+
+Coordinates the five pilot KPI pillars, Pau aesthetic engine,
+biometric Sovereign Fit logic, and finance links for the Galeries
+Lafayette pilot.
+
+Patent: PCT/EP2025/067317
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+__all__ = [
+    "DivineoGlobalOrchestrator",
+    "get_orchestrator_status",
+    "get_pilot_kpis",
+    "trigger_global_authority",
+]
+
+_PATENT = "PCT/EP2025/067317"
+_SIREN = "943610196"
+_ARCHITECTURE = "Pegaso V9.2.6"
+_ENGINE_VERSION = "V12_Pau_Core_Engine"
+_MISSION = "Redéfinir le Luxe Digital"
+
+PILOT_KPI_ACTIONS = [
+    {
+        "id": "perfect_selection",
+        "label_fr": "Ma Sélection Parfaite",
+        "label_en": "My Perfect Selection",
+        "label_es": "Mi Selección Perfecta",
+        "endpoint": "/api/v1/pau/perfect-selection",
+        "method": "POST",
+    },
+    {
+        "id": "reserve_cabin",
+        "label_fr": "Réserver en Cabine",
+        "label_en": "Reserve Fitting Room",
+        "label_es": "Reservar en Probador",
+        "endpoint": "/api/v1/pau/reserve",
+        "method": "POST",
+    },
+    {
+        "id": "view_combinations",
+        "label_fr": "Voir les Combinaisons",
+        "label_en": "View Combinations",
+        "label_es": "Ver las Combinaciones",
+        "endpoint": "/api/v1/pau/snap",
+        "method": "POST",
+    },
+    {
+        "id": "save_silhouette",
+        "label_fr": "Enregistrer ma Silhouette",
+        "label_en": "Save My Silhouette",
+        "label_es": "Guardar mi Silueta",
+        "endpoint": "/api/v1/mirror/save-silhouette",
+        "method": "POST",
+    },
+    {
+        "id": "share_look",
+        "label_fr": "Partager le Look",
+        "label_en": "Share the Look",
+        "label_es": "Compartir el Look",
+        "endpoint": "/api/v1/mirror/share-look",
+        "method": "POST",
+    },
+]
+
+MASTER_BRANDS = ["BALMAIN", "DIOR", "PRADA", "CHANEL", "YSL"]
+
+
+class DivineoGlobalOrchestrator:
+    """Orchestrates fashion + technology + business for the Lafayette pilot."""
+
+    def __init__(self) -> None:
+        self.mission = _MISSION
+        self.architecture = _ARCHITECTURE
+        self.patent = _PATENT
+        self.siren = _SIREN
+        self.engine_version = _ENGINE_VERSION
+        self.stripe_configured = bool(
+            (os.getenv("STRIPE_SECRET_KEY") or "").strip()
+        )
+        self.supabase_configured = bool(
+            (os.getenv("SUPABASE_SERVICE_ROLE_KEY") or "").strip()
+        )
+
+    def execute_global_authority(self) -> dict[str, Any]:
+        """Return Pau aesthetic config, biometric engine, and brand triggers."""
+        return {
+            "pau_behaviour": "Eric_Lafayette_Refined",
+            "snap_gesture": "Snap_Gesture",
+            "master_brands": MASTER_BRANDS,
+            "certified_by": "Google_Developer_Expert",
+            "infrastructure": "Vercel_Serverless_Omega_V10",
+            "architecture": self.architecture,
+        }
+
+    def business_impact_logic(self) -> dict[str, Any]:
+        """Zero-Size protocol + finance links for the pilot."""
+        return {
+            "zero_size_protocol": {
+                "no_numbers": True,
+                "standard": "High_Fidelity_Fit",
+                "return_reduction_pct": 85,
+            },
+            "finance": {
+                "setup_fee_eur": 88000,
+                "royalty_pct": 6.5,
+                "virement_check": "MT103_Verified",
+                "client": "Galeries_Lafayette_Haussmann",
+            },
+            "stripe_configured": self.stripe_configured,
+        }
+
+    def finalize_global_deployment(self) -> dict[str, Any]:
+        """Activation of the 5 pilot KPI pillars."""
+        return {
+            "pilot_kpis": PILOT_KPI_ACTIONS,
+            "kpi_count": len(PILOT_KPI_ACTIONS),
+            "deployment_status": "LIVE",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+
+
+_INSTANCE: DivineoGlobalOrchestrator | None = None
+
+
+def _get_instance() -> DivineoGlobalOrchestrator:
+    global _INSTANCE
+    if _INSTANCE is None:
+        _INSTANCE = DivineoGlobalOrchestrator()
+    return _INSTANCE
+
+
+def get_orchestrator_status() -> dict[str, Any]:
+    """Full orchestrator status payload."""
+    orch = _get_instance()
+    return {
+        "mission": orch.mission,
+        "architecture": orch.architecture,
+        "patent": orch.patent,
+        "siren": orch.siren,
+        "engine_version": orch.engine_version,
+        "stripe_configured": orch.stripe_configured,
+        "supabase_configured": orch.supabase_configured,
+        "master_brands": MASTER_BRANDS,
+        "pilot_kpis": PILOT_KPI_ACTIONS,
+        "deployment_status": "LIVE",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def get_pilot_kpis() -> list[dict[str, str]]:
+    """Return the five pilot KPI action definitions."""
+    return PILOT_KPI_ACTIONS
+
+
+def trigger_global_authority() -> dict[str, Any]:
+    """Execute full orchestration: authority + impact + deployment."""
+    orch = _get_instance()
+    return {
+        "authority": orch.execute_global_authority(),
+        "business_impact": orch.business_impact_logic(),
+        "deployment": orch.finalize_global_deployment(),
+    }

--- a/api/index.py
+++ b/api/index.py
@@ -122,6 +122,11 @@ persist_event = _i['persist_event'] or (lambda *a, **kw: None)
 persist_session = _i['persist_session'] or (lambda *a, **kw: None)
 save_control_state = _i['save_control_state'] or (lambda *a, **kw: None)
 
+_i = _safe_import('divineo_global_orchestrator', ['get_orchestrator_status', 'get_pilot_kpis', 'trigger_global_authority'])
+get_orchestrator_status = _i['get_orchestrator_status']
+get_pilot_kpis = _i['get_pilot_kpis']
+trigger_global_authority = _i['trigger_global_authority']
+
 app = Flask(__name__)
 
 @app.route('/api/debug-boot')
@@ -1965,10 +1970,46 @@ def health():
             "enregistrer_ma_silhouette",
             "partager_le_look",
         ],
+        "divineo_global_orchestrator": get_orchestrator_status is not None,
+        "orchestrator_architecture": "Pegaso V9.2.6",
         "qonto_swift_webhook_available": True,
         "smtp_bounce_handler_available": True,
     })), 200
 
+
+
+# ── Divineo Global Orchestrator Routes ──────────────────────────────────────
+
+@app.route("/api/v1/orchestrator/status", methods=["OPTIONS"])
+def orchestrator_status_options():
+    return _cors(Response("", status=204))
+
+@app.route("/api/v1/orchestrator/status", methods=["GET"])
+def orchestrator_status():
+    if not get_orchestrator_status:
+        return _cors(jsonify({"error": "orchestrator_not_available"})), 503
+    return _cors(jsonify(get_orchestrator_status())), 200
+
+@app.route("/api/v1/orchestrator/kpis", methods=["OPTIONS"])
+def orchestrator_kpis_options():
+    return _cors(Response("", status=204))
+
+@app.route("/api/v1/orchestrator/kpis", methods=["GET"])
+def orchestrator_kpis():
+    if not get_pilot_kpis:
+        return _cors(jsonify({"error": "orchestrator_not_available"})), 503
+    return _cors(jsonify({"kpis": get_pilot_kpis()})), 200
+
+@app.route("/api/v1/orchestrator/execute", methods=["OPTIONS"])
+def orchestrator_execute_options():
+    return _cors(Response("", status=204))
+
+@app.route("/api/v1/orchestrator/execute", methods=["POST"])
+def orchestrator_execute():
+    if not trigger_global_authority:
+        return _cors(jsonify({"error": "orchestrator_not_available"})), 503
+    result = trigger_global_authority()
+    return _cors(jsonify(result)), 200
 
 
 # ── Core Engine V11 Routes ──────────────────────────────────────────────────

--- a/src/App.css
+++ b/src/App.css
@@ -2489,3 +2489,102 @@ button {
     bottom: 70px;
   }
 }
+
+/* ── Orchestration Panel ─────────────────────────────────── */
+.orchestration-panel {
+  background: rgba(20, 22, 25, 0.85);
+  border: 1px solid rgba(212, 175, 55, 0.2);
+  border-radius: 16px;
+  padding: 32px;
+  backdrop-filter: blur(12px);
+}
+
+.orchestration-panel--loading {
+  text-align: center;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.orchestration-panel__subtitle {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 14px;
+  margin: 8px 0 24px;
+  letter-spacing: 0.5px;
+}
+
+.orchestration-panel__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.orchestration-panel__card {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.orchestration-panel__card--wide {
+  grid-column: 1 / -1;
+}
+
+.orchestration-panel__label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.orchestration-panel__value {
+  font-size: 16px;
+  font-weight: 600;
+  color: #fff;
+  letter-spacing: 0.5px;
+}
+
+.orchestration-panel__brands {
+  font-size: 13px;
+  letter-spacing: 2px;
+  color: #d4af37;
+}
+
+.orchestration-panel__kpis {
+  border-top: 1px solid rgba(212, 175, 55, 0.15);
+  padding-top: 16px;
+}
+
+.orchestration-panel__kpi-list {
+  list-style: none;
+  padding: 0;
+  margin: 10px 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.orchestration-panel__kpi-item {
+  background: rgba(212, 175, 55, 0.08);
+  border: 1px solid rgba(212, 175, 55, 0.2);
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 12px;
+  letter-spacing: 0.8px;
+  color: rgba(255, 255, 255, 0.8);
+  text-transform: uppercase;
+}
+
+@media (max-width: 600px) {
+  .orchestration-panel__grid {
+    grid-template-columns: 1fr;
+  }
+  .orchestration-panel__card--wide {
+    grid-column: 1;
+  }
+  .orchestration-panel {
+    padding: 20px;
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { OfrendaOverlay, type OfrendaKey } from "./components/OfrendaOverlay";
 import { PauFloatingGuide } from "./components/PauFloatingGuide";
 import { PreScanHook } from "./components/PreScanHook";
 import { DigitalMirrorPanel } from "./components/DigitalMirrorPanel";
+import { OrchestrationPanel } from "./components/OrchestrationPanel";
 import RealTimeAvatar from "./components/RealTimeAvatar";
 import { ORO_DIVINEO, SOVEREIGN_FIT_LABEL } from "./divineo/divineoV11Config";
 import { getDivineoCheckoutUrl } from "./divineo/envBootstrap";
@@ -1444,6 +1445,12 @@ export default function App() {
         <section className="section">
           <div className="section-shell">
             <p className="manifesto-bottom reveal">{staticCopy.manifesto}</p>
+          </div>
+        </section>
+
+        <section className="section" id="orchestration">
+          <div className="section-shell">
+            <OrchestrationPanel locale={locale} />
           </div>
         </section>
       </main>

--- a/src/components/OrchestrationPanel.tsx
+++ b/src/components/OrchestrationPanel.tsx
@@ -1,0 +1,151 @@
+import { useCallback, useEffect, useState } from "react";
+import { motion } from "framer-motion";
+import { ORO_DIVINEO } from "../divineo/divineoV11Config";
+import type { AppLocale } from "../locales/salesCopy";
+
+type OrchestratorStatus = {
+  mission: string;
+  architecture: string;
+  patent: string;
+  engine_version: string;
+  master_brands: string[];
+  deployment_status: string;
+  pilot_kpis: { id: string; label_fr: string; label_en: string; label_es: string }[];
+};
+
+const PANEL_COPY: Record<AppLocale, {
+  title: string;
+  subtitle: string;
+  architecture: string;
+  brands: string;
+  kpis: string;
+  status: string;
+  live: string;
+  offline: string;
+  loading: string;
+}> = {
+  fr: {
+    title: "Orchestration Globale",
+    subtitle: "Moda × Technologie × Business — Pilot Lafayette",
+    architecture: "Architecture",
+    brands: "Maisons",
+    kpis: "Piliers pilote",
+    status: "Statut déploiement",
+    live: "LIVE",
+    offline: "Hors-ligne",
+    loading: "Chargement…",
+  },
+  en: {
+    title: "Global Orchestration",
+    subtitle: "Fashion × Technology × Business — Lafayette Pilot",
+    architecture: "Architecture",
+    brands: "Maisons",
+    kpis: "Pilot pillars",
+    status: "Deployment status",
+    live: "LIVE",
+    offline: "Offline",
+    loading: "Loading…",
+  },
+  es: {
+    title: "Orquestación Global",
+    subtitle: "Moda × Tecnología × Negocio — Piloto Lafayette",
+    architecture: "Arquitectura",
+    brands: "Maisons",
+    kpis: "Pilares piloto",
+    status: "Estado de despliegue",
+    live: "LIVE",
+    offline: "Sin conexión",
+    loading: "Cargando…",
+  },
+};
+
+type Props = {
+  locale: AppLocale;
+};
+
+export function OrchestrationPanel({ locale }: Props) {
+  const copy = PANEL_COPY[locale];
+  const [data, setData] = useState<OrchestratorStatus | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const res = await fetch("/api/v1/orchestrator/status", { credentials: "same-origin" });
+      if (res.ok) {
+        const json = await res.json();
+        setData(json);
+      }
+    } catch { /* offline fallback */ }
+    setLoaded(true);
+  }, []);
+
+  useEffect(() => {
+    void fetchStatus();
+  }, [fetchStatus]);
+
+  const kpiLabel = (kpi: { label_fr: string; label_en: string; label_es: string }) => {
+    if (locale === "fr") return kpi.label_fr;
+    if (locale === "es") return kpi.label_es;
+    return kpi.label_en;
+  };
+
+  if (!loaded) {
+    return (
+      <div className="orchestration-panel orchestration-panel--loading">
+        <p>{copy.loading}</p>
+      </div>
+    );
+  }
+
+  const isLive = data?.deployment_status === "LIVE";
+
+  return (
+    <motion.div
+      className="orchestration-panel"
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.3 }}
+      transition={{ duration: 0.5 }}
+    >
+      <h3 style={{ color: ORO_DIVINEO, margin: 0 }}>{copy.title}</h3>
+      <p className="orchestration-panel__subtitle">{copy.subtitle}</p>
+
+      <div className="orchestration-panel__grid">
+        <div className="orchestration-panel__card">
+          <span className="orchestration-panel__label">{copy.architecture}</span>
+          <span className="orchestration-panel__value">
+            {data?.architecture ?? "Pegaso V9.2.6"}
+          </span>
+        </div>
+
+        <div className="orchestration-panel__card">
+          <span className="orchestration-panel__label">{copy.status}</span>
+          <span
+            className="orchestration-panel__value"
+            style={{ color: isLive ? "#4ade80" : "#f87171" }}
+          >
+            {isLive ? copy.live : copy.offline}
+          </span>
+        </div>
+
+        <div className="orchestration-panel__card orchestration-panel__card--wide">
+          <span className="orchestration-panel__label">{copy.brands}</span>
+          <span className="orchestration-panel__value orchestration-panel__brands">
+            {(data?.master_brands ?? ["BALMAIN", "DIOR", "PRADA", "CHANEL", "YSL"]).join(" · ")}
+          </span>
+        </div>
+      </div>
+
+      <div className="orchestration-panel__kpis">
+        <span className="orchestration-panel__label">{copy.kpis}</span>
+        <ul className="orchestration-panel__kpi-list">
+          {(data?.pilot_kpis ?? []).map((kpi) => (
+            <li key={kpi.id} className="orchestration-panel__kpi-item">
+              {kpiLabel(kpi)}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </motion.div>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the **DivineoGlobalOrchestrator** — the coordination layer that unifies Fashion × Technology × Business for the Galeries Lafayette pilot under the Pegaso V9.2.6 architecture.

## Changes

### Backend (`api/divineo_global_orchestrator.py`)
- New `DivineoGlobalOrchestrator` class coordinating:
  - **Pau Aesthetic Engine** — Eric Lafayette personality, snap gesture, master brand triggers (BALMAIN, DIOR, PRADA, CHANEL, YSL)
  - **Zero-Size Protocol** — 85% return reduction via High Fidelity Fit (no weight/size exposed)
  - **Finance Links** — Setup fee 88,000€, royalty 6.5%, MT103 verification for Lafayette Haussmann
  - **5 Pilot KPI Pillars** — Ma Sélection Parfaite, Réserver en Cabine, Voir les Combinaisons, Enregistrer ma Silhouette, Partager le Look

### API Endpoints (wired in `api/index.py`)
| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/v1/orchestrator/status` | Full orchestrator status payload |
| GET | `/api/v1/orchestrator/kpis` | Pilot KPI action definitions |
| POST | `/api/v1/orchestrator/execute` | Execute full authority + impact + deployment |

### Frontend (`src/components/OrchestrationPanel.tsx`)
- New orchestration panel with full FR/EN/ES i18n
- Displays architecture version, deployment status (LIVE/Offline), master brands, and pilot KPI pills
- Antracite/Gold styling consistent with Divineo V11 design language
- Inserted between manifesto and footer sections in `App.tsx`

## Verification
- TypeScript typecheck: **0 errors**
- Vite production build: **0 errors/warnings** (442 modules, 2.26s)
- Python module import: verified end-to-end
- Patent: PCT/EP2025/067317
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://tryonyou.slack.com/archives/D0AP1MQ3517/p1776001179723309?thread_ts=1776001179.723309&cid=D0AP1MQ3517)

<div><a href="https://cursor.com/agents/bc-cd403a70-db42-5033-bb4f-5b2d97fe0d24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd403a70-db42-5033-bb4f-5b2d97fe0d24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

