### PR TITLE
🧹 [code health improvement] Remove unused import in bunker_consolidator.py

### DIFF
--- a/bunker_consolidator.py
+++ b/bunker_consolidator.py
@@ -7,7 +7,6 @@ Bajo Protocolo de Soberanía V10 - Founder: Rubén
 from __future__ import annotations
 
 import json
-import os
 import shutil
 import subprocess
 import sys


### PR DESCRIPTION
🎯 **What:** Removed the unused `import os` statement from `bunker_consolidator.py`.
💡 **Why:** `os` was imported but never used, as the script correctly uses `pathlib.Path` for filesystem operations. Removing it cleans up the namespace and improves readability.
✅ **Verification:** Verified that the syntax is correct with `python3 -m py_compile bunker_consolidator.py`. The change is safe as it only removes an unused import.
✨ **Result:** Improved code cleanliness without changing behavior.

---
*PR created automatically by Jules for task [1449921429323155741](https://jules.google.com/task/1449921429323155741) started by @LVT-ENG*