### PR TITLE
🧹 Remove unused annotations import in enviar_correo_soberano.py

### DIFF
--- a/enviar_correo_soberano.py
+++ b/enviar_correo_soberano.py
@@ -13,7 +13,6 @@ Envío Soberano — SMTP Gmail con credenciales solo en entorno (nunca en el rep
 Patente: PCT/EP2025/067317 — @CertezaAbsoluta @lo+erestu
 Bajo Protocolo de Soberanía V10 - Founder: Rubén
 """
-from __future__ import annotations
 
 import argparse
 import os

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,4 @@
+🎯 **What:** Removed unused `from __future__ import annotations` from `enviar_correo_soberano.py`.
+💡 **Why:** This improves maintainability by removing unnecessary and unused dead code.
+✅ **Verification:** Verified safe via `git diff` and running `pytest tests/`, confirming no dependencies broke and formatting remains intact.
+✨ **Result:** Cleaned up unused import successfully.


### PR DESCRIPTION
🎯 **What:** Removed unused `from __future__ import annotations` from `enviar_correo_soberano.py`.
💡 **Why:** This improves maintainability by removing unnecessary and unused dead code.
✅ **Verification:** Verified safe via `git diff` and running `pytest tests/`, confirming no dependencies broke and formatting remains intact.
✨ **Result:** Cleaned up unused import successfully.

---
*PR created automatically by Jules for task [16881523841321748817](https://jules.google.com/task/16881523841321748817) started by @LVT-ENG*