### PR TITLE
🧹 [code health improvement] Remove unused annotations import in fix_marais.py

### DIFF
--- a/fix_marais.py
+++ b/fix_marais.py
@@ -5,7 +5,6 @@ No sobrescribe .env entero: fusiona claves VITE_* para no perder el resto del bu
 
 Patente: PCT/EP2025/067317 — Bajo Protocolo de Soberanía V10 - Founder: Rubén
 """
-from __future__ import annotations
 
 import json
 import re


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` from `fix_marais.py`.
💡 **Why:** The file does not contain any type hints requiring postponed evaluation, so this import is redundant. Removing it improves code health and resolves the linting issue.
✅ **Verification:** Verified syntax manually with `python3 -m py_compile fix_marais.py`, and ran the backend test suite via `pytest tests/` (which passed).
✨ **Result:** A cleaner codebase without any changes to functionality.

---
*PR created automatically by Jules for task [1977513107180827255](https://jules.google.com/task/1977513107180827255) started by @LVT-ENG*