### PR TITLE
🧹 [Code Health] Remove unused annotations import in asalto_final.py

### DIFF
--- a/asalto_final.py
+++ b/asalto_final.py
@@ -8,8 +8,6 @@ Paso 3: git push a main (opcionalmente --force), sin shell=True.
 Ejecutar: python3 asalto_final.py
 """
 
-from __future__ import annotations
-
 import os
 import subprocess
 import sys


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` import from `asalto_final.py`.
💡 **Why:** This file runs in a modern Python environment where future annotations aren't strictly required for backwards compatibility in this context, and since they weren't being used, it merely cluttered the file. Removing unused imports improves readability and slightly reduces the cognitive load of reading the script.
✅ **Verification:** I ran `python3 -m py_compile asalto_final.py` to guarantee no syntax errors were introduced. The full backend test suite (`pytest tests/`) was also executed and it passed (ignoring tests missing third-party dependencies unresolvable in the sandbox), ensuring no regressions.
✨ **Result:** The codebase is cleaner and adheres more strictly to best practices for dead code elimination.

---
*PR created automatically by Jules for task [14929093736580581564](https://jules.google.com/task/14929093736580581564) started by @LVT-ENG*