### PR TITLE
🧪 [testing improvement] Add tests for resolve_stripe_secret fallback

### DIFF
--- a/tests/test_stripe_verify_secret_env.py
+++ b/tests/test_stripe_verify_secret_env.py
@@ -1,0 +1,49 @@
+"""Tests for stripe_verify_secret_env.py — env resolution."""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), ".."))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from stripe_verify_secret_env import resolve_stripe_secret
+
+class TestResolveStripeSecret(unittest.TestCase):
+    def test_prefers_fr_key(self) -> None:
+        with patch.dict(os.environ, {
+            "STRIPE_SECRET_KEY_FR": "sk_fr_123",
+            "STRIPE_SECRET_KEY_NUEVA": "sk_nueva_456",
+            "STRIPE_SECRET_KEY": "sk_base_789"
+        }, clear=True):
+            self.assertEqual(resolve_stripe_secret(), "sk_fr_123")
+
+    def test_falls_back_to_nueva_key(self) -> None:
+        with patch.dict(os.environ, {
+            "STRIPE_SECRET_KEY_NUEVA": "sk_nueva_456",
+            "STRIPE_SECRET_KEY": "sk_base_789"
+        }, clear=True):
+            self.assertEqual(resolve_stripe_secret(), "sk_nueva_456")
+
+    def test_falls_back_to_base_key(self) -> None:
+        with patch.dict(os.environ, {
+            "STRIPE_SECRET_KEY": " sk_base_789 "
+        }, clear=True):
+            self.assertEqual(resolve_stripe_secret(), "sk_base_789")
+
+    def test_ignores_empty_strings(self) -> None:
+        with patch.dict(os.environ, {
+            "STRIPE_SECRET_KEY_FR": "  ",
+            "STRIPE_SECRET_KEY_NUEVA": "",
+            "STRIPE_SECRET_KEY": "sk_base_789"
+        }, clear=True):
+            self.assertEqual(resolve_stripe_secret(), "sk_base_789")
+
+    def test_returns_empty_when_no_keys_present(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(resolve_stripe_secret(), "")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that `resolve_stripe_secret` lacked unit tests validating its internal environment variable fallback logic (preferring FR over NUEVA over base).
📊 **Coverage:** Test coverage was added for all conditions including normal valid strings, empty space strings, missing environment keys, and proper order of precedence, effectively utilizing `unittest.mock.patch.dict` to simulate these varying environments securely.
✨ **Result:** Test coverage for `resolve_stripe_secret`'s behavior is now explicitly covered, resulting in increased stability and preventing unintended key resolution issues from bad deployments.

---
*PR created automatically by Jules for task [3899959224586341372](https://jules.google.com/task/3899959224586341372) started by @LVT-ENG*