### PR TITLE
🧹 [Code Health] Remove unused __future__ annotations import

### DIFF
--- a/bunker_consolidator.py
+++ b/bunker_consolidator.py
@@ -4,7 +4,6 @@ Consolidación de build de producción — identidad legal + Vite (sin pisar sec
 Patente: PCT/EP2025/067317 — @CertezaAbsoluta @lo+erestu
 Bajo Protocolo de Soberanía V10 - Founder: Rubén
 """
-from __future__ import annotations
 
 import json
 import os

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,6 @@
+🎯 **What:** Removed the unused `from __future__ import annotations` in `bunker_consolidator.py`.
+💡 **Why:** The codebase is using Python 3.12, which natively supports modern type hints (like `list[str]`, `set[str]`) without requiring the future import. The import was unused and its removal cleans up dead code.
+✅ **Verification:**
+- Verified that `bunker_consolidator.py` compiles successfully using `python3 -m py_compile`.
+- Automated test collection confirmed the fix did not introduce any syntax errors.
+✨ **Result:** Improved code health and cleanliness by removing a redundant and unnecessary import.


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` in `bunker_consolidator.py`.
💡 **Why:** The codebase is using Python 3.12, which natively supports modern type hints (like `list[str]`, `set[str]`) without requiring the future import. The import was unused and its removal cleans up dead code.
✅ **Verification:**
- Verified that `bunker_consolidator.py` compiles successfully using `python3 -m py_compile`.
- Automated test collection confirmed the fix did not introduce any syntax errors.
✨ **Result:** Improved code health and cleanliness by removing a redundant and unnecessary import.

---
*PR created automatically by Jules for task [2223520732910274256](https://jules.google.com/task/2223520732910274256) started by @LVT-ENG*