### PR TITLE
🔒 Fix overly permissive CORS policy

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 import csv
 from io import BytesIO
@@ -15,9 +16,21 @@ app = FastAPI(
     description="Servidor maestro unificado con catálogo extendido de marcas Lafayette"
 )
 
+allowed_origins_env = os.getenv("E50_CORS_ALLOW_ORIGIN")
+if allowed_origins_env:
+    allowed_origins = [origin.strip() for origin in allowed_origins_env.split(",") if origin.strip()]
+else:
+    allowed_origins = [
+        "https://tryonyou.app",
+        "https://abvetos.com",
+        "https://tryonyou.lafayette.demo",
+        "http://localhost:5173",
+        "http://localhost:8000",
+    ]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was an overly permissive CORS configuration in `main.py` which allowed any origin (`allow_origins=["*"]`) combined with `allow_credentials=True`.

⚠️ **Risk:** The potential impact if left unfixed would allow malicious sites to make cross-origin requests using the credentials (like cookies or tokens) of authenticated users, exposing sensitive data.

🛡️ **Solution:** The fix restricts `allow_origins` to a controlled list of domains, sourced from the `E50_CORS_ALLOW_ORIGIN` environment variable or defaulting to a list of known and trusted internal and production URLs.

---
*PR created automatically by Jules for task [7261607923006850119](https://jules.google.com/task/7261607923006850119) started by @LVT-ENG*