### PR TITLE
🧹 [code health improvement] Remove unused annotations import

### DIFF
--- a/enviar_correo_soberano.py
+++ b/enviar_correo_soberano.py
@@ -13,7 +13,6 @@ Envío Soberano — SMTP Gmail con credenciales solo en entorno (nunca en el rep
 Patente: PCT/EP2025/067317 — @CertezaAbsoluta @lo+erestu
 Bajo Protocolo de Soberanía V10 - Founder: Rubén
 """
-from __future__ import annotations
 
 import argparse
 import os


### PR DESCRIPTION
🎯 **What:** Removed `from __future__ import annotations` from `enviar_correo_soberano.py`.
💡 **Why:** The codebase uses Python 3.12+, where forward declarations for type hinting are natively supported. This unused import is obsolete and removing it improves code cleanliness.
✅ **Verification:** Verified that the file compiles successfully with `py_compile` and that the full test suite passes with `pytest`.
✨ **Result:** Improved readability by eliminating dead code without affecting logic.

---
*PR created automatically by Jules for task [12834470314384670413](https://jules.google.com/task/12834470314384670413) started by @LVT-ENG*