### PR TITLE
🧹 [Code Health] Remove unused annotations import in genesis_consolidacion_total.py

### DIFF
--- a/genesis_consolidacion_total.py
+++ b/genesis_consolidacion_total.py
@@ -1,7 +1,5 @@
 """Alias de genesis_consolidacion_total_safe."""
 
-from __future__ import annotations
-
 import sys
 
 from genesis_consolidacion_total_safe import genesis_consolidacion_total_safe


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` from `genesis_consolidacion_total.py`.
💡 **Why:** Improves maintainability by removing unnecessary imports and keeping the file clean. Since this codebase uses Python 3.12, forward-compatibility imports for annotations are mostly obsolete for standard usage anyway.
✅ **Verification:** Validated the script syntax using `python3 -m py_compile genesis_consolidacion_total.py` and ran the full unit test suite via `pytest`.
✨ **Result:** A cleaner script with one less unnecessary import and no functional changes.

---
*PR created automatically by Jules for task [8411610848752630932](https://jules.google.com/task/8411610848752630932) started by @LVT-ENG*