### PR TITLE
🧹 [Code Health] Remove unused annotations import from genesis_consolidacion_total.py

### DIFF
--- a/genesis_consolidacion_total.py
+++ b/genesis_consolidacion_total.py
@@ -1,7 +1,5 @@
 """Alias de genesis_consolidacion_total_safe."""
 
-from __future__ import annotations
-
 import sys
 
 from genesis_consolidacion_total_safe import genesis_consolidacion_total_safe


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` import in `genesis_consolidacion_total.py`.
💡 **Why:** This improves maintainability and readability by removing a dead import that is no longer necessary in Python 3.12 environments (the standard runtime for this project).
✅ **Verification:** Syntactic correctness verified by running `python3 -m py_compile genesis_consolidacion_total.py`. `pytest` collection issues related to absent environment dependencies persist, but no logic or actual functionality is impacted.
✨ **Result:** A cleaner codebase with fewer unnecessary imports and a more consistent code health status.

---
*PR created automatically by Jules for task [902095165794585894](https://jules.google.com/task/902095165794585894) started by @LVT-ENG*