### PR TITLE
🧹 Remove unused annotations import from genesis_consolidacion_total.py

### DIFF
--- a/genesis_consolidacion_total.py
+++ b/genesis_consolidacion_total.py
@@ -1,7 +1,5 @@
 """Alias de genesis_consolidacion_total_safe."""
 
-from __future__ import annotations
-
 import sys
 
 from genesis_consolidacion_total_safe import genesis_consolidacion_total_safe


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` import from `genesis_consolidacion_total.py`.
💡 **Why:** This improves maintainability by removing an obsolete import (since the project uses Python 3.12 and only uses the built-in `int` for typing in this file) and reduces visual clutter.
✅ **Verification:** Validated syntax with `py_compile` and confirmed the script runs successfully without errors.
✨ **Result:** Cleaner code without functional changes.

---
*PR created automatically by Jules for task [13521891739112523052](https://jules.google.com/task/13521891739112523052) started by @LVT-ENG*