### PR TITLE
🧹 Remove unused annotations import in fix_marais.py

### DIFF
--- a/fix_marais.py
+++ b/fix_marais.py
@@ -5,7 +5,6 @@ No sobrescribe .env entero: fusiona claves VITE_* para no perder el resto del bu
 
 Patente: PCT/EP2025/067317 — Bajo Protocolo de Soberanía V10 - Founder: Rubén
 """
-from __future__ import annotations
 
 import json
 import re


### PR DESCRIPTION
🎯 **What:** Removed unused 'from __future__ import annotations' import from 'fix_marais.py'
💡 **Why:** Cleans up dead code. The project is using python 3.12+ which makes future annotations imports mostly unnecessary or obsolete, and it wasn't even being used here anyway.
✅ **Verification:** Verified via 'python3 -m py_compile fix_marais.py' and 'pytest'.
✨ **Result:** Improved code cleanliness.

---
*PR created automatically by Jules for task [1379790409542866945](https://jules.google.com/task/1379790409542866945) started by @LVT-ENG*