### PR TITLE
🔒 Fix overly permissive CORS policy in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,9 +15,24 @@ app = FastAPI(
     description="Servidor maestro unificado con catálogo extendido de marcas Lafayette"
 )
 
+import os
+
+# Load CORS origins strictly via env var with fallbacks for specified domains
+allowed_origins_env = os.environ.get("E50_CORS_ALLOW_ORIGIN", "")
+if allowed_origins_env:
+    allowed_origins = [origin.strip() for origin in allowed_origins_env.split(",")]
+else:
+    allowed_origins = [
+        "https://abvetos.com",
+        "https://tryonyou.app",
+        "https://tryonyou.lafayette.demo",
+        "http://localhost:5173",
+        "http://127.0.0.1:5173"
+    ]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # Core API
 fastapi>=0.115.0
 uvicorn[standard]>=0.32.0
-pydantic>=2.0
+pydantic[email]>=2.0
 qrcode[pil]>=7.4.2
 stripe>=11.0.0
 

--- a/tests/test_cors_security.py
+++ b/tests/test_cors_security.py
@@ -1,0 +1,32 @@
+import unittest
+from fastapi.testclient import TestClient
+from main import app
+
+class TestCorsSecurity(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+
+    def test_allowed_origin(self):
+        headers = {
+            "Origin": "https://abvetos.com",
+            "Access-Control-Request-Method": "GET",
+        }
+        response = self.client.options("/status", headers=headers)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("access-control-allow-origin", response.headers)
+        self.assertEqual(response.headers["access-control-allow-origin"], "https://abvetos.com")
+
+    def test_disallowed_origin(self):
+        headers = {
+            "Origin": "https://evil-attacker.com",
+            "Access-Control-Request-Method": "GET",
+        }
+        response = self.client.options("/status", headers=headers)
+        self.assertEqual(response.status_code, 400)
+        # Note: Depending on the ASGI server / CORSMiddleware implementation,
+        # it might just not return the CORS headers or might return 400.
+        # FastAPI/Starlette CORSMiddleware returns 400 Bad Request for disallowed preflight.
+        self.assertNotIn("access-control-allow-origin", response.headers)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The CORS middleware was previously configured with `allow_origins=['*']` and `allow_credentials=True`, which is an insecure configuration that allows any origin to make authenticated requests to the API.

⚠️ **Risk:** The potential impact if left unfixed
An attacker could perform Cross-Site Request Forgery (CSRF) or access sensitive user data by tricking an authenticated user into visiting a malicious website that makes unauthorized requests to the API.

🛡️ **Solution:** How the fix addresses the vulnerability
The CORS policy has been updated to use an explicit list of allowed origins. It first checks for an environment variable `E50_CORS_ALLOW_ORIGIN` and falls back to a predefined list of trusted domains. This prevents unauthorized domains from accessing the API while maintaining required functionality for authorized clients. A unit test was also added using `FastAPI TestClient` to explicitly verify that unauthorized origins are rejected.

---
*PR created automatically by Jules for task [3739388482808441672](https://jules.google.com/task/3739388482808441672) started by @LVT-ENG*