### PR TITLE
🧪 Add test coverage for unificar_v10._free_port_5173

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,5 @@
+Title: "🧪 Add test coverage for unificar_v10._free_port_5173"
+Description:
+🎯 **What:** This PR addresses a testing gap by adding unit tests for the `_free_port_5173` function in `unificar_v10.py`, which had no previous test coverage.
+📊 **Coverage:** The new tests in `tests/test_unificar_v10.py` cover three core scenarios: MacOS (Darwin), Linux, and Windows (NT). We successfully mock `sys.platform`, `os.name`, and `subprocess.run` to ensure the correct bash and powershell commands are constructed and executed respectively across these platforms without side effects.
+✨ **Result:** Test coverage improved by ensuring regressions in the port termination logic can be caught natively.

--- a/tests/test_unificar_v10.py
+++ b/tests/test_unificar_v10.py
@@ -1,0 +1,48 @@
+import unittest
+from unittest.mock import patch
+import sys
+import subprocess
+
+from unificar_v10 import _free_port_5173, VITE_PORT
+
+class TestUnificarV10(unittest.TestCase):
+    @patch('unificar_v10.sys')
+    @patch('unificar_v10.subprocess.run')
+    def test_free_port_darwin(self, mock_run, mock_sys):
+        mock_sys.platform = 'darwin'
+        _free_port_5173()
+        mock_run.assert_called_once_with(
+            f"lsof -ti:{VITE_PORT} | xargs kill -9 2>/dev/null || true",
+            shell=True,
+            stderr=subprocess.DEVNULL,
+        )
+
+    @patch('unificar_v10.sys')
+    @patch('unificar_v10.subprocess.run')
+    def test_free_port_linux(self, mock_run, mock_sys):
+        mock_sys.platform = 'linux'
+        _free_port_5173()
+        mock_run.assert_called_once_with(
+            f"lsof -ti:{VITE_PORT} | xargs kill -9 2>/dev/null || true",
+            shell=True,
+            stderr=subprocess.DEVNULL,
+        )
+
+    @patch('unificar_v10.os')
+    @patch('unificar_v10.sys')
+    @patch('unificar_v10.subprocess.run')
+    def test_free_port_windows(self, mock_run, mock_sys, mock_os):
+        mock_sys.platform = 'win32'
+        mock_os.name = 'nt'
+        _free_port_5173()
+        ps = (
+            "Get-NetTCPConnection -LocalPort 5173 -ErrorAction SilentlyContinue "
+            "| ForEach-Object { Stop-Process -Id $_.OwningProcess -Force -ErrorAction SilentlyContinue }"
+        )
+        mock_run.assert_called_once_with(
+            ["powershell", "-NoProfile", "-Command", ps],
+            stderr=subprocess.DEVNULL,
+        )
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** This PR addresses a testing gap by adding unit tests for the `_free_port_5173` function in `unificar_v10.py`, which had no previous test coverage.
📊 **Coverage:** The new tests in `tests/test_unificar_v10.py` cover three core scenarios: MacOS (Darwin), Linux, and Windows (NT). We successfully mock `sys.platform`, `os.name`, and `subprocess.run` to ensure the correct bash and powershell commands are constructed and executed respectively across these platforms without side effects.
✨ **Result:** Test coverage improved by ensuring regressions in the port termination logic can be caught natively.

---
*PR created automatically by Jules for task [5211844405994052756](https://jules.google.com/task/5211844405994052756) started by @LVT-ENG*