### PR TITLE
🧪 [testing improvement] add edge case tests for computeElasticityRatio

### DIFF
--- a/src/lib/fabricFitComparator.test.ts
+++ b/src/lib/fabricFitComparator.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { computeElasticityRatio, NormalizedLandmark } from './fabricFitComparator';
+
+describe('computeElasticityRatio', () => {
+  const createLandmarks = (
+    l11: NormalizedLandmark = { x: 0, y: 0 },
+    l12: NormalizedLandmark = { x: 0, y: 0 },
+    l23: NormalizedLandmark = { x: 0, y: 0 },
+    l24: NormalizedLandmark = { x: 0, y: 0 }
+  ): NormalizedLandmark[] => {
+    const arr = new Array(25).fill({ x: 0, y: 0 });
+    arr[11] = l11;
+    arr[12] = l12;
+    arr[23] = l23;
+    arr[24] = l24;
+    return arr;
+  };
+
+  it('should return 0.5 if landmarks is null', () => {
+    expect(computeElasticityRatio(null as any)).toBe(0.5);
+  });
+
+  it('should return 0.5 if landmarks length < 25', () => {
+    expect(computeElasticityRatio(new Array(24).fill({ x: 0, y: 0 }))).toBe(0.5);
+  });
+
+  it('should return the correct ratio for normal landmarks', () => {
+    // Shoulder dist = dist({x:0,y:0}, {x:3,y:4}) = 5
+    // Hip dist = dist({x:0,y:0}, {x:0,y:2}) = 2
+    // Ratio = 5 / 2 = 2.5
+    const landmarks = createLandmarks(
+      { x: 0, y: 0 }, { x: 3, y: 4 },
+      { x: 0, y: 0 }, { x: 0, y: 2 }
+    );
+    expect(computeElasticityRatio(landmarks)).toBe(2.5);
+  });
+
+  it('should handle zero hip distance using 1e-6', () => {
+    // Shoulder dist = dist({x:0,y:0}, {x:2,y:0}) = 2
+    // Hip dist = dist({x:1,y:1}, {x:1,y:1}) = 0
+    // Ratio = 2 / 1e-6 = 2000000
+    const landmarks = createLandmarks(
+      { x: 0, y: 0 }, { x: 2, y: 0 },
+      { x: 1, y: 1 }, { x: 1, y: 1 }
+    );
+    expect(computeElasticityRatio(landmarks)).toBe(2000000);
+  });
+
+  it('should handle zero shoulder distance', () => {
+    // Shoulder dist = dist({x:0,y:0}, {x:0,y:0}) = 0
+    // Hip dist = dist({x:0,y:0}, {x:0,y:2}) = 2
+    // Ratio = 0 / 2 = 0
+    const landmarks = createLandmarks(
+      { x: 0, y: 0 }, { x: 0, y: 0 },
+      { x: 0, y: 0 }, { x: 0, y: 2 }
+    );
+    expect(computeElasticityRatio(landmarks)).toBe(0);
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of unit tests covering the `computeElasticityRatio` function in `src/lib/fabricFitComparator.ts`. This function performs mathematical operations (calculating elasticity ratios from normalized landmarks) and had no existing tests.
📊 **Coverage:** Created a new file `src/lib/fabricFitComparator.test.ts`. Scenarios covered include:
- When the `landmarks` array is null.
- When the `landmarks` array length is less than 25.
- Normal calculation cases based on standard landmarks.
- Edge case where hip distance is exactly 0 (verifying division by `1e-6` fallback).
- Edge case where shoulder distance is 0.
✨ **Result:** Enhanced the reliability and coverage of the fabric elasticity math processing, ensuring confident refactoring without the fear of silently breaking the computation logic.

---
*PR created automatically by Jules for task [1106533032337093005](https://jules.google.com/task/1106533032337093005) started by @LVT-ENG*