### PR TITLE
🧹 Remove unused import `annotations` from `genesis_consolidacion_total.py`

### DIFF
--- a/genesis_consolidacion_total.py
+++ b/genesis_consolidacion_total.py
@@ -1,7 +1,5 @@
 """Alias de genesis_consolidacion_total_safe."""
 
-from __future__ import annotations
-
 import sys
 
 from genesis_consolidacion_total_safe import genesis_consolidacion_total_safe


### PR DESCRIPTION
🎯 **What:** Removed unused import `annotations` from `genesis_consolidacion_total.py`.
💡 **Why:** `genesis_consolidacion_total.py` imports `annotations` from `__future__` but doesn't use it. This removes the unused import to improve code readability and maintainability.
✅ **Verification:** Verified by compiling `genesis_consolidacion_total.py` via `python3 -m py_compile genesis_consolidacion_total.py` and running tests via `PYTHONPATH=. python3 -m pytest tests/`.
✨ **Result:** The code compiles and tests pass successfully with no errors or regressions.

---
*PR created automatically by Jules for task [9938004845536076699](https://jules.google.com/task/9938004845536076699) started by @LVT-ENG*