### PR TITLE
🔒 Fix OS Command Injection vulnerability in shell=True subprocess calls

### DIFF
--- a/maza_final_v10.py
+++ b/maza_final_v10.py
@@ -11,10 +11,10 @@ def sellar_bunker_git():
     print(f"🏛️  [ERIC] Sellando Propiedad en GitHub (V10.4 Omega)...")
     os.chdir(PROJECT_ROOT)
     # Limpiamos cualquier rastro previo para asegurar subida limpia
-    subprocess.run("git add .", shell=True)
+    subprocess.run(["git", "add", "."])
     msg = f"V10.4 OMEGA: Bunker 75005 Blindado - Patente {PATENTE}"
-    subprocess.run(f'git commit -m "{msg}"', shell=True)
-    subprocess.run("git push origin main --force", shell=True)
+    subprocess.run(["git", "commit", "-m", msg])
+    subprocess.run(["git", "push", "origin", "main", "--force"])
     print("✅ GitHub: Sincronizado y Blindado sin secretos expuestos.")
 
 def generar_mazas_cobro():

--- a/unificar_v10.py
+++ b/unificar_v10.py
@@ -49,11 +49,15 @@ def _gemini_key() -> str:
 def _free_port_5173() -> None:
     print(f"🧹 Liberando puerto {VITE_PORT} si está ocupado...")
     if sys.platform == "darwin" or sys.platform.startswith("linux"):
-        subprocess.run(
-            f"lsof -ti:{VITE_PORT} | xargs kill -9 2>/dev/null || true",
-            shell=True,
-            stderr=subprocess.DEVNULL,
-        )
+        # Obtenemos los PIDs y los matamos sin usar shell=True
+        try:
+            p = subprocess.Popen(["lsof", "-ti", f":{VITE_PORT}"], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True)
+            out, _ = p.communicate()
+            pids = out.strip().split()
+            if pids:
+                subprocess.run(["kill", "-9"] + pids, stderr=subprocess.DEVNULL)
+        except Exception:
+            pass
     elif os.name == "nt":
         ps = (
             "Get-NetTCPConnection -LocalPort 5173 -ErrorAction SilentlyContinue "

--- a/vigilancia_pau.py
+++ b/vigilancia_pau.py
@@ -12,7 +12,10 @@ def disparar_sincronizacion_bunker() -> None:
     if not cmd:
         return
     print(f"⚙️  BUNKER_SYNC_CMD: {cmd[:80]}{'…' if len(cmd) > 80 else ''}")
-    subprocess.run(cmd, shell=True, check=False)
+    import shlex
+    cmd_args = shlex.split(cmd)
+    if cmd_args:
+        subprocess.run(cmd_args, check=False)
 
 
 def vigilancia_silenciosa(


### PR DESCRIPTION
🎯 **What:** Refactored `subprocess.run` calls in `maza_final_v10.py`, `unificar_v10.py`, and `vigilancia_pau.py` to use a list of arguments and `shell=False`.
⚠️ **Risk:** Command injection if arguments were attacker-controlled, as well as general fragility with shell character escaping and piped commands. Use of `shell=True` exposes the system to potential arbitrary command execution.
🛡️ **Solution:** Changed string commands to lists of strings (e.g., `["git", "add", "."]`) and removed the `shell=True` flag. For commands with pipes or complex shell semantics, rewrote them securely (e.g., using `subprocess.Popen` to capture `stdout` and pass the results to another safe `subprocess.run` list call, or utilizing `shlex.split()`).

---
*PR created automatically by Jules for task [11575984820655773024](https://jules.google.com/task/11575984820655773024) started by @LVT-ENG*