### PR TITLE
🧪 Add test for OSError path in terminar_web_ahora.py

### DIFF
--- a/tests/test_terminar_web_ahora.py
+++ b/tests/test_terminar_web_ahora.py
@@ -1,0 +1,15 @@
+import unittest
+from unittest.mock import patch
+
+from terminar_web_ahora import _run
+
+class TestTerminarWebAhora(unittest.TestCase):
+
+    @patch('terminar_web_ahora.subprocess.run')
+    def test_run_oserror(self, mock_run):
+        mock_run.side_effect = OSError("Mocked OS error")
+        result = _run(["mock", "command"])
+        self.assertFalse(result)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** Adds test for `_run` function handling `OSError` in `terminar_web_ahora.py`.
📊 **Coverage:** Mocked `subprocess.run` to raise `OSError` to cover the exception block.
✨ **Result:** Improved test coverage and reliability for OS command failure handling.

---
*PR created automatically by Jules for task [6753936590423713995](https://jules.google.com/task/6753936590423713995) started by @LVT-ENG*