### PR TITLE
🔒 [security fix] Fix overly permissive CORS policy

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 import csv
 from io import BytesIO
@@ -17,7 +18,7 @@ app = FastAPI(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=os.environ.get("E50_CORS_ALLOW_ORIGIN", "https://tryonyou.app,https://abvetos.com").split(","),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
In `main.py`, the FastAPI/Starlette CORS middleware was improperly configured with `allow_origins=["*"]` alongside `allow_credentials=True`.

⚠️ **Risk:** The potential impact if left unfixed
Allowing all origins (`*`) while enabling credentials (`allow_credentials=True`) is a significant security risk. It permits malicious websites to make cross-origin requests to the API with user credentials (cookies, authorization headers), potentially leading to unauthorized data access or actions on behalf of the user (Cross-Site Request Forgery - CSRF). Many modern frameworks either crash or inherently echo the `Origin` header to simulate a wildcard in these scenarios, creating a severe vulnerability.

🛡️ **Solution:** How the fix addresses the vulnerability
The configuration in `main.py` was updated to retrieve a comma-separated list of allowed origins from the `E50_CORS_ALLOW_ORIGIN` environment variable. If the variable is not set, it defaults to a strict, secure fallback list (`https://tryonyou.app` and `https://abvetos.com`), explicitly removing the dangerous `"*"` wildcard.

---
*PR created automatically by Jules for task [8603911827789053540](https://jules.google.com/task/8603911827789053540) started by @LVT-ENG*