### PR TITLE
🔒 Fix overly permissive CORS header in preflight and json responses

### DIFF
--- a/api/financial_guard.py
+++ b/api/financial_guard.py
@@ -137,7 +137,7 @@ def _cors_json_response(payload: dict, status: int):
 
     body = json.dumps(payload, ensure_ascii=False)
     r = Response(body, status=status, mimetype="application/json; charset=utf-8")
-    r.headers["Access-Control-Allow-Origin"] = "*"
+    r.headers["Access-Control-Allow-Origin"] = os.environ.get("E50_CORS_ALLOW_ORIGIN", "")
     r.headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
     r.headers["Access-Control-Allow-Headers"] = "Content-Type"
     return r
@@ -147,7 +147,7 @@ def _cors_preflight_no_content() -> object:
     from flask import Response
 
     r = Response(status=204)
-    r.headers["Access-Control-Allow-Origin"] = "*"
+    r.headers["Access-Control-Allow-Origin"] = os.environ.get("E50_CORS_ALLOW_ORIGIN", "")
     r.headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
     r.headers["Access-Control-Allow-Headers"] = "Content-Type"
     r.headers["Access-Control-Max-Age"] = "86400"


### PR DESCRIPTION
🎯 What: Replaced wildcard origin ('*') with restrictive environment variable in preflight and JSON CORS responses.
⚠️ Risk: The wildcard origin allows any site to perform cross-origin requests, potentially exposing sensitive endpoints to abuse or data leakage.
🛡️ Solution: Updated api/financial_guard.py to fetch 'E50_CORS_ALLOW_ORIGIN' from the environment, defaulting to an empty string to restrict access when unconfigured.

---
*PR created automatically by Jules for task [18418424706018614979](https://jules.google.com/task/18418424706018614979) started by @LVT-ENG*