### PR TITLE
🧪 Refactored getLafayetteStripeCheckoutUrl for testing and added tests

### DIFF
--- a/src/lib/lafayetteCheckout.test.ts
+++ b/src/lib/lafayetteCheckout.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { getLafayetteStripeCheckoutUrl } from "./lafayetteCheckout";
+
+describe("getLafayetteStripeCheckoutUrl", () => {
+  it("returns VITE_LAFAYETTE_STRIPE_CHECKOUT_URL if it exists", () => {
+    const mockEnv = {
+      VITE_LAFAYETTE_STRIPE_CHECKOUT_URL: "https://lafayette.example.com",
+      VITE_STRIPE_LINK_SOVEREIGNTY_4_5M: "https://sov45m.example.com",
+    };
+    expect(getLafayetteStripeCheckoutUrl(mockEnv)).toBe("https://lafayette.example.com");
+  });
+
+  it("returns VITE_STRIPE_LINK_SOVEREIGNTY_4_5M if VITE_LAFAYETTE_STRIPE_CHECKOUT_URL is missing", () => {
+    const mockEnv = {
+      VITE_LAFAYETTE_STRIPE_CHECKOUT_URL: undefined,
+      VITE_STRIPE_LINK_SOVEREIGNTY_4_5M: "https://sov45m.example.com",
+      VITE_STRIPE_CHECKOUT_URL: "https://checkout.example.com",
+    };
+    expect(getLafayetteStripeCheckoutUrl(mockEnv)).toBe("https://sov45m.example.com");
+  });
+
+  it("returns VITE_STRIPE_CHECKOUT_URL if the first two are missing", () => {
+    const mockEnv = {
+      VITE_STRIPE_CHECKOUT_URL: "https://checkout.example.com",
+      VITE_STRIPE_LINK_SOVEREIGNTY_98K: "https://sov98k.example.com",
+    };
+    expect(getLafayetteStripeCheckoutUrl(mockEnv)).toBe("https://checkout.example.com");
+  });
+
+  it("returns VITE_STRIPE_LINK_SOVEREIGNTY_98K if it is the only one present", () => {
+    const mockEnv = {
+      VITE_STRIPE_LINK_SOVEREIGNTY_98K: "https://sov98k.example.com",
+    };
+    expect(getLafayetteStripeCheckoutUrl(mockEnv)).toBe("https://sov98k.example.com");
+  });
+
+  it("returns an empty string if no valid candidate is found", () => {
+    const mockEnv = {};
+    expect(getLafayetteStripeCheckoutUrl(mockEnv)).toBe("");
+  });
+
+  it("ignores whitespace-only strings and moves to the next candidate", () => {
+    const mockEnv = {
+      VITE_LAFAYETTE_STRIPE_CHECKOUT_URL: "   ",
+      VITE_STRIPE_LINK_SOVEREIGNTY_4_5M: "https://sov45m.example.com",
+    };
+    expect(getLafayetteStripeCheckoutUrl(mockEnv)).toBe("https://sov45m.example.com");
+  });
+
+  it("trims whitespace from the returned string", () => {
+    const mockEnv = {
+      VITE_LAFAYETTE_STRIPE_CHECKOUT_URL: "  https://lafayette.example.com  ",
+    };
+    expect(getLafayetteStripeCheckoutUrl(mockEnv)).toBe("https://lafayette.example.com");
+  });
+});

--- a/src/lib/lafayetteCheckout.ts
+++ b/src/lib/lafayetteCheckout.ts
@@ -21,8 +21,8 @@ export {
   getStripePublishableKeyParis,
 };
 
-export function getLafayetteStripeCheckoutUrl(): string {
-  const e = import.meta.env;
+export function getLafayetteStripeCheckoutUrl(e: Record<string, any> = import.meta.env): string {
+
   const candidates = [
     e.VITE_LAFAYETTE_STRIPE_CHECKOUT_URL,
     e.VITE_STRIPE_LINK_SOVEREIGNTY_4_5M,


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was testing the `getLafayetteStripeCheckoutUrl` function in `src/lib/lafayetteCheckout.ts`, which has fallback logic dependent on `import.meta.env`.
📊 **Coverage:** Covered fallback logic prioritizing properties from the `env` object: `VITE_LAFAYETTE_STRIPE_CHECKOUT_URL`, `VITE_STRIPE_LINK_SOVEREIGNTY_4_5M`, `VITE_STRIPE_CHECKOUT_URL`, `VITE_STRIPE_LINK_SOVEREIGNTY_98K`. Also added cases for blank string trimmings and default empty string returns.
✨ **Result:** Improved robustness by testing what returns out of `getLafayetteStripeCheckoutUrl` through dependency injection in the function parameter.

---
*PR created automatically by Jules for task [6020467250226138240](https://jules.google.com/task/6020467250226138240) started by @LVT-ENG*