### PR TITLE
🧪 [testing improvement] Add boolean parsing tests for isSovereigntyLicenseActive

### DIFF
--- a/src/lib/licenseGate.test.ts
+++ b/src/lib/licenseGate.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { isSovereigntyLicenseActive } from './licenseGate';
+
+describe('isSovereigntyLicenseActive', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns true for truthy values', () => {
+    vi.stubEnv('VITE_LICENSE_PAID', 'true');
+    expect(isSovereigntyLicenseActive()).toBe(true);
+
+    vi.stubEnv('VITE_LICENSE_PAID', '1');
+    expect(isSovereigntyLicenseActive()).toBe(true);
+
+    vi.stubEnv('VITE_LICENSE_PAID', 'yes');
+    expect(isSovereigntyLicenseActive()).toBe(true);
+
+    vi.stubEnv('VITE_LICENSE_PAID', 'on');
+    expect(isSovereigntyLicenseActive()).toBe(true);
+  });
+
+  it('returns false for falsy or invalid values', () => {
+    vi.stubEnv('VITE_LICENSE_PAID', '');
+    expect(isSovereigntyLicenseActive()).toBe(false);
+
+    vi.stubEnv('VITE_LICENSE_PAID', 'false');
+    expect(isSovereigntyLicenseActive()).toBe(false);
+
+    vi.stubEnv('VITE_LICENSE_PAID', '0');
+    expect(isSovereigntyLicenseActive()).toBe(false);
+
+    vi.stubEnv('VITE_LICENSE_PAID', 'no');
+    expect(isSovereigntyLicenseActive()).toBe(false);
+
+    vi.stubEnv('VITE_LICENSE_PAID', 'random_string');
+    expect(isSovereigntyLicenseActive()).toBe(false);
+  });
+
+  it('returns false when env is undefined', () => {
+    const original = process.env.VITE_LICENSE_PAID;
+    delete process.env.VITE_LICENSE_PAID;
+    expect(isSovereigntyLicenseActive()).toBe(false);
+    process.env.VITE_LICENSE_PAID = original;
+  });
+
+  it('handles case insensitivity and whitespace', () => {
+    vi.stubEnv('VITE_LICENSE_PAID', ' TRUE ');
+    expect(isSovereigntyLicenseActive()).toBe(true);
+
+    vi.stubEnv('VITE_LICENSE_PAID', 'Yes');
+    expect(isSovereigntyLicenseActive()).toBe(true);
+
+    vi.stubEnv('VITE_LICENSE_PAID', ' ON\n');
+    expect(isSovereigntyLicenseActive()).toBe(true);
+  });
+});


### PR DESCRIPTION
🎯 **What:** Missing tests for boolean parsing in isSovereigntyLicenseActive. The function accesses \`import.meta.env.VITE_LICENSE_PAID\` to determine whether a sovereignty license is active, but there were no tests to verify the behavior of the parsing logic across different possible inputs.
📊 **Coverage:** Created tests for truthy inputs ('true', '1', 'yes', 'on'), falsy inputs (undefined, '', 'false', '0', 'no'), and boundary conditions like case insensitivity and whitespace handling. These scenarios are tested using \`vi.stubEnv\`.
✨ **Result:** Improved test coverage and reliability of the codebase by verifying behavior around boolean parsing.

---
*PR created automatically by Jules for task [9507081275471172621](https://jules.google.com/task/9507081275471172621) started by @LVT-ENG*