### PR TITLE
🔒 Fix overly permissive CORS policy

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -11,7 +11,12 @@ app = FastAPI(title="TRYONYOU Divineo V7 - Production Core API")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=[
+        "https://tryonyou.app",
+        "https://www.tryonyou.app",
+        "http://localhost:5173",
+        "http://localhost:3000"
+    ],
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was an overly permissive CORS configuration in `api/index.py` which had `allow_origins=["*"]`.
⚠️ **Risk:** The previous configuration allowed any third-party website to make cross-origin requests to the API. This is a significant security risk, as it bypasses the same-origin policy and could allow attackers to steal sensitive user data or perform actions on behalf of a logged-in user if they are tricked into visiting a malicious site.
🛡️ **Solution:** The fix replaces the wildcard with an explicit, strictly controlled list of allowed origins. It hardcodes the production domains (`https://tryonyou.app`, `https://www.tryonyou.app`) and standard local development ports (`http://localhost:5173`, `http://localhost:3000`), ensuring that only authorized frontend clients can communicate with the backend API.

---
*PR created automatically by Jules for task [6783583597334029969](https://jules.google.com/task/6783583597334029969) started by @LVT-ENG*