### PR TITLE
🔒 Fix overly permissive CORS policy

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -9,12 +9,38 @@ from typing import Optional, List
 
 app = FastAPI(title="TRYONYOU Divineo V7 - Production Core API")
 
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+raw_origins = os.environ.get("E50_CORS_ALLOW_ORIGIN", "")
+allowed_origins = [o.strip() for o in raw_origins.split(",") if o.strip()]
+
+TRUSTED_DOMAINS = ["abvetos.com", "tryonyou.app", "tryonme.com", "tryonme.app", "tryonme.org"]
+domain_pattern = "|".join([d.replace(".", r"\.") for d in TRUSTED_DOMAINS])
+
+if allowed_origins:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=allowed_origins,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+else:
+    # Set explicit allow_origins since allow_origin_regex seems to be misbehaving with TestClient
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=[
+            "http://localhost:5173",
+            "http://127.0.0.1:5173",
+            "http://localhost:8000",
+            "https://tryonyou.app",
+            "https://api.tryonyou.app",
+            "https://abvetos.com",
+            "https://tryonme.com",
+            "https://tryonme.app",
+            "https://tryonme.org"
+        ],
+        allow_origin_regex=rf"^https?://(?:[a-zA-Z0-9-]+\.)*(?:{domain_pattern})$",
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 
 
 @app.post("/")
@@ -23,7 +49,6 @@ async def block_root_post():
     return JSONResponse(
         status_code=404,
         content={"status": "error", "message": "Not Found"},
-        headers={"Access-Control-Allow-Origin": "*"},
     )
 
 

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,9 @@
+🎯 **What:** The vulnerability fixed
+The CORS middleware in `api/index.py` was configured with `allow_origins=["*"]`. This is an overly permissive CORS policy that allows any domain to read the responses of the API, regardless of whether they should have access.
+
+⚠️ **Risk:** The potential impact if left unfixed
+An attacker could host a malicious website and trick a user into visiting it. The malicious website could then make authenticated requests to the API on behalf of the user, potentially exposing sensitive biometric data, sizing information, or making unauthorized actions (like checking out).
+
+🛡️ **Solution:** How the fix addresses the vulnerability
+The wildcard `["*"]` in the `allow_origins` array was replaced with an explicit list of trusted origins.
+It supports a dynamic list provided by the `E50_CORS_ALLOW_ORIGIN` environment variable (which is already used by `blindar_api_pagos.py` in the project), and if that is not provided, it falls back to a restricted list of explicitly trusted domains (e.g. `tryonyou.app`, `abvetos.com`) and localhost ports used for development. Tests were updated and added to ensure proper origin validation.

--- a/tests/test_cors_vulnerability.py
+++ b/tests/test_cors_vulnerability.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from fastapi.testclient import TestClient
+
+_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), ".."))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from api.index import app
+
+class TestCORSVulnerability(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = TestClient(app)
+
+    def check_origin(self, origin: str) -> str | None:
+        headers = {"Origin": origin, "Access-Control-Request-Method": "GET"}
+        # Assuming there is a valid route or using OPTIONS
+        response = self.client.options("/api/v1/scan", headers=headers)
+        return response.headers.get("access-control-allow-origin")
+
+    def test_allowed_origins(self) -> None:
+        self.assertEqual(self.check_origin("https://tryonyou.app"), "https://tryonyou.app")
+        self.assertEqual(self.check_origin("https://api.tryonyou.app"), "https://api.tryonyou.app")
+        self.assertEqual(self.check_origin("https://abvetos.com"), "https://abvetos.com")
+        self.assertEqual(self.check_origin("http://localhost:5173"), "http://localhost:5173")
+
+    def test_disallowed_origins(self) -> None:
+        self.assertIsNone(self.check_origin("https://evil.com"))
+        self.assertIsNone(self.check_origin("http://malicious.org"))
+        self.assertIsNone(self.check_origin("https://tryonyou.app.evil.com"))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_root_route_protection.py
+++ b/tests/test_root_route_protection.py
@@ -30,7 +30,9 @@ class TestRootRouteProtection(unittest.TestCase):
         )
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.json(), {"status": "error", "message": "Not Found"})
-        self.assertEqual(response.headers.get("access-control-allow-origin"), "*")
+        # Expect no Access-Control-Allow-Origin header because we are not sending an Origin header
+        # and CORS middleware won't add it automatically unless it matches the whitelist.
+        self.assertIsNone(response.headers.get("access-control-allow-origin"))
 
     def test_vercel_api_rewrite_to_index(self) -> None:
         vercel_json = Path(_ROOT, "vercel.json")


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The CORS middleware in `api/index.py` was configured with `allow_origins=["*"]`. This is an overly permissive CORS policy that allows any domain to read the responses of the API, regardless of whether they should have access.

⚠️ **Risk:** The potential impact if left unfixed
An attacker could host a malicious website and trick a user into visiting it. The malicious website could then make authenticated requests to the API on behalf of the user, potentially exposing sensitive biometric data, sizing information, or making unauthorized actions (like checking out). 

🛡️ **Solution:** How the fix addresses the vulnerability
The wildcard `["*"]` in the `allow_origins` array was replaced with an explicit list of trusted origins. 
It supports a dynamic list provided by the `E50_CORS_ALLOW_ORIGIN` environment variable (which is already used by `blindar_api_pagos.py` in the project), and if that is not provided, it falls back to a restricted list of explicitly trusted domains (e.g. `tryonyou.app`, `abvetos.com`) and localhost ports used for development. Tests were updated and added to ensure proper origin validation.

---
*PR created automatically by Jules for task [5540058178188290262](https://jules.google.com/task/5540058178188290262) started by @LVT-ENG*