### PR TITLE
🔒 Fix overly permissive CORS headers

### DIFF
--- a/api/financial_guard.py
+++ b/api/financial_guard.py
@@ -64,10 +64,14 @@ def qonto_pago_confirmado() -> bool:
     if (os.environ.get("FINANCIAL_GUARD_SKIP") or "").strip() == "1":
         return True
     v = (
-        os.environ.get("QONTO_PAGO_CONFIRMADO")
-        or os.environ.get("PAGO_CONFIRMADO_QONTO")
-        or ""
-    ).strip().lower()
+        (
+            os.environ.get("QONTO_PAGO_CONFIRMADO")
+            or os.environ.get("PAGO_CONFIRMADO_QONTO")
+            or ""
+        )
+        .strip()
+        .lower()
+    )
     return v in ("1", "true", "yes")
 
 
@@ -137,7 +141,9 @@ def _cors_json_response(payload: dict, status: int):
 
     body = json.dumps(payload, ensure_ascii=False)
     r = Response(body, status=status, mimetype="application/json; charset=utf-8")
-    r.headers["Access-Control-Allow-Origin"] = "*"
+    r.headers["Access-Control-Allow-Origin"] = os.environ.get(
+        "E50_CORS_ALLOW_ORIGIN", "*"
+    )
     r.headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
     r.headers["Access-Control-Allow-Headers"] = "Content-Type"
     return r
@@ -147,7 +153,9 @@ def _cors_preflight_no_content() -> object:
     from flask import Response
 
     r = Response(status=204)
-    r.headers["Access-Control-Allow-Origin"] = "*"
+    r.headers["Access-Control-Allow-Origin"] = os.environ.get(
+        "E50_CORS_ALLOW_ORIGIN", "*"
+    )
     r.headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
     r.headers["Access-Control-Allow-Headers"] = "Content-Type"
     r.headers["Access-Control-Max-Age"] = "86400"
@@ -257,7 +265,10 @@ def register_financial_guard_middleware(app) -> None:
         except Exception as e:
             logger.debug("FinancialGuard audit: %s", e)
 
-        if exit_after_mirror_402_enabled() and request.environ.get("financial_guard_402") == "1":
+        if (
+            exit_after_mirror_402_enabled()
+            and request.environ.get("financial_guard_402") == "1"
+        ):
             if is_mirror_request_path(request.path) and response.status_code == 402:
                 with _exit_lock:
                     if not _exit_scheduled:
@@ -282,7 +293,10 @@ _LOG_FILE = os.getenv(
 )
 
 _logger = logging.getLogger("financial_guard.stripe_resilience")
-if not any(isinstance(h, (logging.FileHandler, logging.StreamHandler)) for h in _logger.handlers):
+if not any(
+    isinstance(h, (logging.FileHandler, logging.StreamHandler))
+    for h in _logger.handlers
+):
     try:
         _handler = logging.FileHandler(_LOG_FILE, encoding="utf-8")
     except OSError:
@@ -346,7 +360,9 @@ def guard_stripe_call(
     return None
 
 
-def resilient_stripe(max_retries: int = MAX_RETRIES, retry_delay: float = RETRY_DELAY_S):
+def resilient_stripe(
+    max_retries: int = MAX_RETRIES, retry_delay: float = RETRY_DELAY_S
+):
     """
     Versión decorador de guard_stripe_call.
     """

--- a/api/index.py
+++ b/api/index.py
@@ -5,13 +5,17 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
-from typing import Optional, List
+from typing import Optional
 
 app = FastAPI(title="TRYONYOU Divineo V7 - Production Core API")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=[
+        origin.strip()
+        for origin in os.environ.get("E50_CORS_ALLOW_ORIGIN", "*").split(",")
+        if origin.strip()
+    ],
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -23,7 +27,9 @@ async def block_root_post():
     return JSONResponse(
         status_code=404,
         content={"status": "error", "message": "Not Found"},
-        headers={"Access-Control-Allow-Origin": "*"},
+        headers={
+            "Access-Control-Allow-Origin": os.environ.get("E50_CORS_ALLOW_ORIGIN", "*")
+        },
     )
 
 
@@ -223,7 +229,10 @@ async def real_biometric_checkout(req: ReservationRequest):
                 "Transaction aborted to prevent simulated financial data."
             ),
         )
-    return {"status": "processing", "message": "Paiement réel en cours d'autorisation..."}
+    return {
+        "status": "processing",
+        "message": "Paiement réel en cours d'autorisation...",
+    }
 
 
 @app.post("/api/v1/empire/payment-intent")

--- a/tests/test_financial_guard_cors.py
+++ b/tests/test_financial_guard_cors.py
@@ -1,0 +1,31 @@
+import os
+from unittest.mock import patch
+from api.financial_guard import _cors_preflight_no_content, _cors_json_response
+
+
+def test_cors_preflight_origin_from_env():
+    test_origin = "https://safe-domain.com"
+    with patch.dict(os.environ, {"E50_CORS_ALLOW_ORIGIN": test_origin}):
+        response = _cors_preflight_no_content()
+        assert response.headers["Access-Control-Allow-Origin"] == test_origin
+
+
+def test_cors_preflight_origin_fallback():
+    if "E50_CORS_ALLOW_ORIGIN" in os.environ:
+        del os.environ["E50_CORS_ALLOW_ORIGIN"]
+    response = _cors_preflight_no_content()
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+
+
+def test_cors_json_response_origin_from_env():
+    test_origin = "https://safe-domain.com"
+    with patch.dict(os.environ, {"E50_CORS_ALLOW_ORIGIN": test_origin}):
+        response = _cors_json_response({"status": "ok"}, 200)
+        assert response.headers["Access-Control-Allow-Origin"] == test_origin
+
+
+def test_cors_json_response_origin_fallback():
+    if "E50_CORS_ALLOW_ORIGIN" in os.environ:
+        del os.environ["E50_CORS_ALLOW_ORIGIN"]
+    response = _cors_json_response({"status": "ok"}, 200)
+    assert response.headers["Access-Control-Allow-Origin"] == "*"


### PR DESCRIPTION
🎯 **What:** The API responded to requests with Access-Control-Allow-Origin: * in both preflight (OPTIONS) requests and JSON responses in api/financial_guard.py as well as in api/index.py.
⚠️ **Risk:** Hardcoding * for CORS origins allows any website to make cross-origin requests to this API and read the response. This could lead to sensitive data exposure, including the deuda_total_eur and other financial metrics from the financial_guard functionality.
🛡️ **Solution:** The hardcoded * origin was replaced with an environment variable E50_CORS_ALLOW_ORIGIN, which falls back to * if not defined. This allows administrators to restrict CORS access to specific, trusted domains in production environments, thereby mitigating the risk of unauthorized cross-origin data access.

---
*PR created automatically by Jules for task [12422680375970596360](https://jules.google.com/task/12422680375970596360) started by @LVT-ENG*