### PR TITLE
🔒 [security fix] Fix Overly Permissive CORS

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -9,9 +9,22 @@ from typing import Optional, List
 
 app = FastAPI(title="TRYONYOU Divineo V7 - Production Core API")
 
+# CORS Security Config
+allowed_origins_env = os.getenv("E50_CORS_ALLOW_ORIGIN")
+if allowed_origins_env:
+    allow_origins = [
+        origin.strip() for origin in allowed_origins_env.split(",") if origin.strip()
+    ]
+else:
+    allow_origins = [
+        "https://tryonyou.app",
+        "http://localhost:5173",
+        "http://localhost:8000",
+    ]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allow_origins,
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -223,7 +236,10 @@ async def real_biometric_checkout(req: ReservationRequest):
                 "Transaction aborted to prevent simulated financial data."
             ),
         )
-    return {"status": "processing", "message": "Paiement réel en cours d'autorisation..."}
+    return {
+        "status": "processing",
+        "message": "Paiement réel en cours d'autorisation...",
+    }
 
 
 @app.post("/api/v1/empire/payment-intent")

--- a/tests/test_cors_security.py
+++ b/tests/test_cors_security.py
@@ -1,0 +1,86 @@
+import os
+import unittest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+
+
+class TestCORSSecurity(unittest.TestCase):
+    def test_cors_allowed_origin_hardcoded(self):
+        # Temporarily patch environment to ensure E50_CORS_ALLOW_ORIGIN is unset
+        with patch.dict(os.environ, {}, clear=True):
+            # Reload module to apply new env vars
+            import importlib
+            import api.index
+
+            importlib.reload(api.index)
+            client = TestClient(api.index.app)
+
+            # https://tryonyou.app should be allowed by default
+            response = client.options(
+                "/",
+                headers={
+                    "Origin": "https://tryonyou.app",
+                    "Access-Control-Request-Method": "POST",
+                },
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(
+                response.headers.get("access-control-allow-origin"),
+                "https://tryonyou.app",
+            )
+
+            # http://malicious.com should NOT be allowed
+            response = client.options(
+                "/",
+                headers={
+                    "Origin": "http://malicious.com",
+                    "Access-Control-Request-Method": "POST",
+                },
+            )
+            self.assertEqual(
+                response.status_code, 400
+            )  # FastAPI returns 400 for disallowed CORS origins
+            self.assertIsNone(response.headers.get("access-control-allow-origin"))
+
+    def test_cors_allowed_origin_env(self):
+        # Patch environment with custom domains
+        with patch.dict(
+            os.environ,
+            {"E50_CORS_ALLOW_ORIGIN": "https://example.com,https://another.com"},
+            clear=True,
+        ):
+            # Reload module to apply new env vars
+            import importlib
+            import api.index
+
+            importlib.reload(api.index)
+            client = TestClient(api.index.app)
+
+            # https://example.com should be allowed
+            response = client.options(
+                "/",
+                headers={
+                    "Origin": "https://example.com",
+                    "Access-Control-Request-Method": "POST",
+                },
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(
+                response.headers.get("access-control-allow-origin"),
+                "https://example.com",
+            )
+
+            # Default hardcoded should NOT be allowed when env var is set
+            response = client.options(
+                "/",
+                headers={
+                    "Origin": "https://tryonyou.app",
+                    "Access-Control-Request-Method": "POST",
+                },
+            )
+            self.assertEqual(response.status_code, 400)
+            self.assertIsNone(response.headers.get("access-control-allow-origin"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The FastAPI backend `api/index.py` was using a wildcard `*` for `allow_origins` in the `CORSMiddleware`, allowing any domain to send Cross-Origin requests.

⚠️ **Risk:** The potential impact if left unfixed
An overly permissive CORS policy can allow malicious sites to perform Cross-Site Request Forgery (CSRF) or read sensitive data from authenticated sessions on behalf of a user without their consent.

🛡️ **Solution:** How the fix addresses the vulnerability
Replaced the wildcard origin configuration with an environment variable-based configuration (`E50_CORS_ALLOW_ORIGIN`). If the environment variable is not present, it defaults to explicit domains specific to this deployment (`https://tryonyou.app` and localhost development ports). This strict enumeration enforces same-origin and trusted-origin policies efficiently. Also added a comprehensive test suite to verify this behavior.

---
*PR created automatically by Jules for task [13875938281633230085](https://jules.google.com/task/13875938281633230085) started by @LVT-ENG*