### PR TITLE
🔒 Fix overly permissive CORS configuration

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -9,9 +9,19 @@ from typing import Optional, List
 
 app = FastAPI(title="TRYONYOU Divineo V7 - Production Core API")
 
+# Get allowed origins from environment or use secure defaults
+allowed_origins_env = os.getenv("E50_CORS_ALLOW_ORIGIN")
+if allowed_origins_env:
+    allowed_origins = [origin.strip() for origin in allowed_origins_env.split(",")]
+else:
+    allowed_origins = [
+        "https://tryonyou.app",
+        "http://localhost:5173",
+    ]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allowed_origins,
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -223,7 +233,10 @@ async def real_biometric_checkout(req: ReservationRequest):
                 "Transaction aborted to prevent simulated financial data."
             ),
         )
-    return {"status": "processing", "message": "Paiement réel en cours d'autorisation..."}
+    return {
+        "status": "processing",
+        "message": "Paiement réel en cours d'autorisation...",
+    }
 
 
 @app.post("/api/v1/empire/payment-intent")

--- a/tests/test_cors_security.py
+++ b/tests/test_cors_security.py
@@ -1,0 +1,31 @@
+import unittest
+from fastapi.testclient import TestClient
+from api.index import app
+
+class TestCORSSecurity(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+
+    def test_cors_allowed_origin(self):
+        # Allow origins fallback is https://tryonyou.app and http://localhost:5173
+        headers = {
+            "Origin": "https://tryonyou.app",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "X-Example"
+        }
+        response = self.client.options("/", headers=headers)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers.get("access-control-allow-origin"), "https://tryonyou.app")
+
+    def test_cors_disallowed_origin(self):
+        headers = {
+            "Origin": "https://evil.com",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "X-Example"
+        }
+        response = self.client.options("/", headers=headers)
+        self.assertEqual(response.status_code, 400) # FastAPI will return 400 for bad origin on preflight, or simply not return CORS header
+        self.assertIsNone(response.headers.get("access-control-allow-origin"))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The FastAPI application was configured with `allow_origins=["*"]`, which is overly permissive. This was fixed by reading the allowed domains from an environment variable `E50_CORS_ALLOW_ORIGIN`, with a safe hardcoded fallback to trusted production (`https://tryonyou.app`) and local development origins (`http://localhost:5173`).

⚠️ **Risk:** Using `*` for CORS origins allows any website to make requests to the API. If cookies/credentials were enabled, it would allow cross-site authenticated requests. Even without credentials, it allows arbitrary websites to read responses from the API, leading to potential data leakage.

🛡️ **Solution:** Restricted the allowed origins by replacing the wildcard with an explicit list loaded from the environment (defaulting to the tryonyou app domain and localhost). Added robust testing (`tests/test_cors_security.py`) to explicitly check that preflight requests from disallowed origins are rejected, returning a 400 status.

---
*PR created automatically by Jules for task [17437107263985794407](https://jules.google.com/task/17437107263985794407) started by @LVT-ENG*