### PR TITLE
🔒 Fix overly permissive CORS configuration

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -9,9 +9,15 @@ from typing import Optional, List
 
 app = FastAPI(title="TRYONYOU Divineo V7 - Production Core API")
 
+cors_origins_env = os.getenv("E50_CORS_ALLOW_ORIGIN")
+if cors_origins_env:
+    allow_origins = [origin.strip() for origin in cors_origins_env.split(",") if origin.strip()]
+else:
+    allow_origins = ["https://tryonyou.app", "http://localhost:5173"]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allow_origins,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/submission.md
+++ b/submission.md
@@ -1,0 +1,8 @@
+🎯 **What:**
+Fixed an overly permissive CORS configuration in FastAPI's Core API (`api/index.py`). The application previously used `allow_origins=["*"]`, allowing any domain to execute requests across origin boundaries.
+
+⚠️ **Risk:**
+Using `*` for CORS origins is a major security vulnerability. It permits malicious websites to make cross-origin requests on behalf of a user who may already be authenticated or hold session data, bypassing the Same-Origin Policy and exposing private actions and biometric functionality.
+
+🛡️ **Solution:**
+Replaced `["*"]` with an environment-based approach. The application now loads allowed origins from the `E50_CORS_ALLOW_ORIGIN` environment variable. If the variable is not set, it fails securely by falling back to explicitly whitelisting `https://tryonyou.app` and `http://localhost:5173`. Added corresponding robust unit tests using `unittest` and `TestClient` to enforce strict domain validation and ensure regressions do not occur.

--- a/tests/test_cors_security.py
+++ b/tests/test_cors_security.py
@@ -1,0 +1,63 @@
+import unittest
+import os
+import importlib
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+import api.index
+
+class TestCorsSecurity(unittest.TestCase):
+    def setUp(self):
+        # We need to reload the module to ensure it picks up the patched environment.
+        # However, to avoid import issues or double initialization that breaks other tests,
+        # we will handle the reload within the specific tests.
+        pass
+
+    def test_cors_fallback_domains(self):
+        """Test that without the env var, CORS defaults to the hardcoded domains."""
+        with patch.dict(os.environ, {}, clear=True):
+            importlib.reload(api.index)
+            client = TestClient(api.index.app)
+
+            # Test allowed origin
+            response = client.options("/", headers={
+                "Origin": "https://tryonyou.app",
+                "Access-Control-Request-Method": "GET"
+            })
+            self.assertEqual(response.headers.get("access-control-allow-origin"), "https://tryonyou.app")
+
+            # Test rejected origin (FastAPI CORSMiddleware does NOT return the header for unallowed origins)
+            response_rejected = client.options("/", headers={
+                "Origin": "https://malicious.com",
+                "Access-Control-Request-Method": "GET"
+            })
+            self.assertIsNone(response_rejected.headers.get("access-control-allow-origin"))
+
+    def test_cors_custom_env_domain(self):
+        """Test that setting E50_CORS_ALLOW_ORIGIN overrides the defaults."""
+        with patch.dict(os.environ, {"E50_CORS_ALLOW_ORIGIN": "https://custom.app,http://localhost:3000"}, clear=True):
+            importlib.reload(api.index)
+            client = TestClient(api.index.app)
+
+            # Test new allowed origin
+            response = client.options("/", headers={
+                "Origin": "https://custom.app",
+                "Access-Control-Request-Method": "GET"
+            })
+            self.assertEqual(response.headers.get("access-control-allow-origin"), "https://custom.app")
+
+            # Test another allowed origin from the list
+            response2 = client.options("/", headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "GET"
+            })
+            self.assertEqual(response2.headers.get("access-control-allow-origin"), "http://localhost:3000")
+
+            # The original fallback domain should now be rejected since the env var overrode it
+            response_rejected = client.options("/", headers={
+                "Origin": "https://tryonyou.app",
+                "Access-Control-Request-Method": "GET"
+            })
+            self.assertIsNone(response_rejected.headers.get("access-control-allow-origin"))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** 
Fixed an overly permissive CORS configuration in FastAPI's Core API (`api/index.py`). The application previously used `allow_origins=["*"]`, allowing any domain to execute requests across origin boundaries.

⚠️ **Risk:** 
Using `*` for CORS origins is a major security vulnerability. It permits malicious websites to make cross-origin requests on behalf of a user who may already be authenticated or hold session data, bypassing the Same-Origin Policy and exposing private actions and biometric functionality.

🛡️ **Solution:** 
Replaced `["*"]` with an environment-based approach. The application now loads allowed origins from the `E50_CORS_ALLOW_ORIGIN` environment variable. If the variable is not set, it fails securely by falling back to explicitly whitelisting `https://tryonyou.app` and `http://localhost:5173`. Added corresponding robust unit tests using `unittest` and `TestClient` to enforce strict domain validation and ensure regressions do not occur.

---
*PR created automatically by Jules for task [4288621582698917306](https://jules.google.com/task/4288621582698917306) started by @LVT-ENG*