### PR TITLE
🧪 [testing improvement] Add tests for _run in inyectar_claves_intelligence.py

### DIFF
--- a/tests/test_inyectar_claves_intelligence.py
+++ b/tests/test_inyectar_claves_intelligence.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+import io
+
+_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), ".."))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from inyectar_claves_intelligence import _run
+
+class TestInyectarClavesIntelligenceRun(unittest.TestCase):
+    @patch("inyectar_claves_intelligence.subprocess.run")
+    def test_run_success(self, mock_run: MagicMock) -> None:
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_run.return_value = mock_result
+
+        result = _run(["echo", "hello"], cwd="/tmp")
+
+        self.assertEqual(result, 0)
+        mock_run.assert_called_once_with(["echo", "hello"], cwd="/tmp", check=False)
+
+    @patch("inyectar_claves_intelligence.subprocess.run")
+    def test_run_failure(self, mock_run: MagicMock) -> None:
+        mock_result = MagicMock()
+        mock_result.returncode = 2
+        mock_run.return_value = mock_result
+
+        result = _run(["false"], cwd="/tmp")
+
+        self.assertEqual(result, 2)
+        mock_run.assert_called_once_with(["false"], cwd="/tmp", check=False)
+
+    @patch("sys.stdout", new_callable=io.StringIO)
+    @patch("inyectar_claves_intelligence.subprocess.run")
+    def test_run_oserror(self, mock_run: MagicMock, mock_stdout: io.StringIO) -> None:
+        mock_run.side_effect = OSError("No such file or directory")
+
+        result = _run(["nonexistent_command"], cwd="/tmp")
+
+        self.assertEqual(result, 1)
+        mock_run.assert_called_once_with(["nonexistent_command"], cwd="/tmp", check=False)
+        self.assertIn("❌ No such file or directory", mock_stdout.getvalue())
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR introduces unit tests for the `_run` function located in `inyectar_claves_intelligence.py`. The `_run` function executes subprocess commands, catches potential `OSError`s, and handles return codes.

📊 **Coverage:** What scenarios are now tested
The new test suite covers three core scenarios:
1.  **Happy Path:** `subprocess.run` succeeds, simulating an exit code of `0`, and the function correctly returns `0`.
2.  **Failure Path:** `subprocess.run` exits with a non-zero code (e.g., `2`), verifying the function properly bubbles up this failure code.
3.  **Error Path:** `subprocess.run` raises an `OSError`, ensuring the exception is caught, the error is printed to stdout, and the function returns the fallback code `1`.

✨ **Result:** The improvement in test coverage
By adding these isolated unit tests using `unittest.mock.patch`, we prevent potential regressions when executing subprocesses without relying on external system states.

---
*PR created automatically by Jules for task [9687092044924147016](https://jules.google.com/task/9687092044924147016) started by @LVT-ENG*