### PR TITLE
🔒 Fix overly permissive CORS configuration

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -7,11 +7,18 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from typing import Optional, List
 
+
+def get_allowed_origins():
+    origins = os.getenv("E50_CORS_ALLOW_ORIGIN")
+    if origins:
+        return [o.strip() for o in origins.split(",")]
+    return ["https://tryonyou.app", "http://localhost:5173"]
+
 app = FastAPI(title="TRYONYOU Divineo V7 - Production Core API")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=get_allowed_origins(),
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 import csv
 from io import BytesIO
@@ -10,6 +11,13 @@ from pydantic import BaseModel, EmailStr
 from typing import List, Dict
 import qrcode
 
+
+def get_allowed_origins():
+    origins = os.getenv("E50_CORS_ALLOW_ORIGIN")
+    if origins:
+        return [o.strip() for o in origins.split(",")]
+    return ["https://tryonyou.app", "http://localhost:5173"]
+
 app = FastAPI(
     title="TRYONYOU - Sistema Central OMEGA V10.2",
     description="Servidor maestro unificado con catálogo extendido de marcas Lafayette"
@@ -17,7 +25,7 @@ app = FastAPI(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=get_allowed_origins(),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # Core API
 fastapi>=0.115.0
 uvicorn[standard]>=0.32.0
-pydantic>=2.0
+pydantic[email]>=2.0
 qrcode[pil]>=7.4.2
 stripe>=11.0.0
 

--- a/tests/test_cors_security.py
+++ b/tests/test_cors_security.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+# Fix sys.path to allow imports from root
+_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), ".."))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+class TestCorsSecurity(unittest.TestCase):
+    def test_main_get_allowed_origins_default(self):
+        from main import get_allowed_origins
+
+        with patch.dict(os.environ, {}, clear=True):
+            origins = get_allowed_origins()
+            self.assertEqual(origins, ["https://tryonyou.app", "http://localhost:5173"])
+
+    def test_main_get_allowed_origins_custom(self):
+        from main import get_allowed_origins
+
+        with patch.dict(os.environ, {"E50_CORS_ALLOW_ORIGIN": "https://example.com,http://localhost:8080"}, clear=True):
+            origins = get_allowed_origins()
+            self.assertEqual(origins, ["https://example.com", "http://localhost:8080"])
+
+    def test_api_index_get_allowed_origins_default(self):
+        from api.index import get_allowed_origins
+
+        with patch.dict(os.environ, {}, clear=True):
+            origins = get_allowed_origins()
+            self.assertEqual(origins, ["https://tryonyou.app", "http://localhost:5173"])
+
+    def test_api_index_get_allowed_origins_custom(self):
+        from api.index import get_allowed_origins
+
+        with patch.dict(os.environ, {"E50_CORS_ALLOW_ORIGIN": "https://test.com, https://test2.com"}, clear=True):
+            origins = get_allowed_origins()
+            self.assertEqual(origins, ["https://test.com", "https://test2.com"])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** Replaced the wildcard `allow_origins=[\"*\"]` with a stricter configuration read from the `E50_CORS_ALLOW_ORIGIN` environment variable in both `main.py` and `api/index.py`.

⚠️ **Risk:** A wildcard origin allowed any website to make cross-origin requests, which could lead to data exfiltration or Cross-Site Request Forgery (CSRF) if sensitive endpoints were exposed, especially when `allow_credentials=True` is also set.

🛡️ **Solution:** Added a `get_allowed_origins()` helper function to dynamically fetch allowed origins from the environment, splitting by comma and stripping whitespace. If not set, it safely falls back to known production and local environments (`https://tryonyou.app` and `http://localhost:5173`). Unit tests were included to verify the logic.

---
*PR created automatically by Jules for task [11259880080645881299](https://jules.google.com/task/11259880080645881299) started by @LVT-ENG*