### PR TITLE
🧪 [testing improvement description for fix_environment.py]

### DIFF
--- a/tests/test_fix_environment.py
+++ b/tests/test_fix_environment.py
@@ -1,0 +1,29 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from fix_environment import _deep_clean_on
+
+
+class TestFixEnvironment(unittest.TestCase):
+    def test_deep_clean_on_truthy(self):
+        truthy_values = ["1", "true", "yes", "on", " 1 ", " TrUe ", "  YES  ", "oN"]
+        for val in truthy_values:
+            with self.subTest(val=val):
+                with patch.dict(os.environ, {"E50_DEEP_CLEAN": val}, clear=True):
+                    self.assertTrue(_deep_clean_on())
+
+    def test_deep_clean_on_falsy(self):
+        falsy_values = ["0", "false", "no", "off", "", " ", "something_else"]
+        for val in falsy_values:
+            with self.subTest(val=val):
+                with patch.dict(os.environ, {"E50_DEEP_CLEAN": val}, clear=True):
+                    self.assertFalse(_deep_clean_on())
+
+    def test_deep_clean_on_unset(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertFalse(_deep_clean_on())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was that `_deep_clean_on()` (the function used to fetch deep clean environment variables from `os.environ.get`) had no corresponding tests.
📊 **Coverage:** The scenarios now tested include testing truthy environment values ("1", "yes", "true", "on", with mixed spaces/casing), falsy environment values ("0", "no", "false", "", etc.), and unset default cases using `patch.dict(os.environ)` to provide isolated tests for `_deep_clean_on`.
✨ **Result:** The improvement in test coverage gives certainty that truthy cases (like exporting `E50_DEEP_CLEAN=1` correctly wipes the cache and `package-lock.json`), will correctly resolve as deep cleaning triggers.

---
*PR created automatically by Jules for task [4292949212177579163](https://jules.google.com/task/4292949212177579163) started by @LVT-ENG*