### PR TITLE
🔒 [security fix] Fix Overly Permissive CORS Configuration

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 import csv
 from io import BytesIO
@@ -12,16 +13,25 @@ import qrcode
 
 app = FastAPI(
     title="TRYONYOU - Sistema Central OMEGA V10.2",
-    description="Servidor maestro unificado con catálogo extendido de marcas Lafayette"
+    description="Servidor maestro unificado con catálogo extendido de marcas Lafayette",
 )
+
+cors_origins_env = os.environ.get("E50_CORS_ALLOW_ORIGIN")
+if cors_origins_env:
+    allow_origins = [
+        origin.strip() for origin in cors_origins_env.split(",") if origin.strip()
+    ]
+else:
+    allow_origins = ["https://tryonyou.app", "http://localhost:5173"]
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=allow_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
 
 DIR_DATA = Path("./data")
 DIR_ASSETS = Path("./assets")
@@ -33,56 +43,146 @@ ARCHIVO_INVITADOS_MUSEUM = DIR_DATA / "lista_invitados_sac_museum.csv"
 if not ARCHIVO_INVITADOS_MUSEUM.exists():
     with open(ARCHIVO_INVITADOS_MUSEUM, "w", newline="", encoding="utf-8") as f:
         writer = csv.writer(f)
-        writer.writerow(["Fecha_Registro", "Email", "Origen_Captacion", "Estado_Invitacion"])
+        writer.writerow(
+            ["Fecha_Registro", "Email", "Origen_Captacion", "Estado_Invitacion"]
+        )
 
 app.mount("/assets", StaticFiles(directory="assets"), name="assets")
+
 
 class DatosSilueta(BaseModel):
     puntos_biometricos: List[float]
     proporciones: Dict[str, float]
 
+
 class PrendaSeleccionada(BaseModel):
     garment_id: str
     talla_calculada: str
 
+
 class PerfilVIP(BaseModel):
     client_token: str
+
 
 class RegistroInvitadoVIP(BaseModel):
     email: EmailStr
     origen: str = "Espejo Digital - Efecto Paloma (Lafayette Haussmann)"
 
+
 CATALOGO_GLOBAL = {
     "balmain": [
-        {"id": "blm_01", "nombre": "Blazer Cruzado Estructurado Pierre", "asset": "/assets/balmain_blazer.png", "planta": "Planta 1 - Córner Lujo"},
-        {"id": "blm_02", "nombre": "Vestido Knit Monograma Geométrico", "asset": "/assets/balmain_dress.png", "planta": "Planta 1 - Córner Lujo"},
-        {"id": "blm_03", "nombre": "Chaqueta Tweed Botones de Oro Vintage", "asset": "/assets/balmain_tweed.png", "planta": "Planta 1 - Córner Lujo"},
-        {"id": "blm_04", "nombre": "Top Corsé de Neopreno Satinado", "asset": "/assets/balmain_corset.png", "planta": "Planta 1 - Córner Lujo"},
-        {"id": "blm_05", "nombre": "Abrigo Largo Masculino de Lana Negra", "asset": "/assets/balmain_coat.png", "planta": "Planta 1 - Córner Lujo"}
+        {
+            "id": "blm_01",
+            "nombre": "Blazer Cruzado Estructurado Pierre",
+            "asset": "/assets/balmain_blazer.png",
+            "planta": "Planta 1 - Córner Lujo",
+        },
+        {
+            "id": "blm_02",
+            "nombre": "Vestido Knit Monograma Geométrico",
+            "asset": "/assets/balmain_dress.png",
+            "planta": "Planta 1 - Córner Lujo",
+        },
+        {
+            "id": "blm_03",
+            "nombre": "Chaqueta Tweed Botones de Oro Vintage",
+            "asset": "/assets/balmain_tweed.png",
+            "planta": "Planta 1 - Córner Lujo",
+        },
+        {
+            "id": "blm_04",
+            "nombre": "Top Corsé de Neopreno Satinado",
+            "asset": "/assets/balmain_corset.png",
+            "planta": "Planta 1 - Córner Lujo",
+        },
+        {
+            "id": "blm_05",
+            "nombre": "Abrigo Largo Masculino de Lana Negra",
+            "asset": "/assets/balmain_coat.png",
+            "planta": "Planta 1 - Córner Lujo",
+        },
     ],
     "prada": [
-        {"id": "prd_01", "nombre": "Abrigo Re-Nylon Minimalista Anthracite", "asset": "/assets/prada_coat.png", "planta": "Planta 2 - Créateurs"},
-        {"id": "prd_02", "nombre": "Falda Plisada de Sarga Estructurada", "asset": "/assets/prada_skirt.png", "planta": "Planta 2 - Créateurs"},
-        {"id": "prd_03", "nombre": "Traje Técnico Gabardina de Corte Sastre", "asset": "/assets/prada_suit.png", "planta": "Planta 2 - Créateurs"},
-        {"id": "prd_04", "nombre": "Chaqueta Corta de Cuero Gastado Umber", "asset": "/assets/prada_leather.png", "planta": "Planta 2 - Créateurs"},
-        {"id": "prd_05", "nombre": "Vestido Popelín con Escote Geométrico", "asset": "/assets/prada_dress.png", "planta": "Planta 2 - Créateurs"}
+        {
+            "id": "prd_01",
+            "nombre": "Abrigo Re-Nylon Minimalista Anthracite",
+            "asset": "/assets/prada_coat.png",
+            "planta": "Planta 2 - Créateurs",
+        },
+        {
+            "id": "prd_02",
+            "nombre": "Falda Plisada de Sarga Estructurada",
+            "asset": "/assets/prada_skirt.png",
+            "planta": "Planta 2 - Créateurs",
+        },
+        {
+            "id": "prd_03",
+            "nombre": "Traje Técnico Gabardina de Corte Sastre",
+            "asset": "/assets/prada_suit.png",
+            "planta": "Planta 2 - Créateurs",
+        },
+        {
+            "id": "prd_04",
+            "nombre": "Chaqueta Corta de Cuero Gastado Umber",
+            "asset": "/assets/prada_leather.png",
+            "planta": "Planta 2 - Créateurs",
+        },
+        {
+            "id": "prd_05",
+            "nombre": "Vestido Popelín con Escote Geométrico",
+            "asset": "/assets/prada_dress.png",
+            "planta": "Planta 2 - Créateurs",
+        },
     ],
     "hermes": [
-        {"id": "rms_01", "nombre": "Capa Corta en Cachemira Bone Hermès", "asset": "/assets/hermes_cape.png", "planta": "Planta 1 - Córner Lujo"},
-        {"id": "rms_02", "nombre": "Pañuelo de Seda Estampado Art Deco", "asset": "/assets/hermes_scarf.png", "planta": "Planta 1 - Córner Lujo"},
-        {"id": "rms_03", "nombre": "Chaqueta de Piel Flexible Suave Ecuestre", "asset": "/assets/hermes_leather.png", "planta": "Planta 1 - Córner Lujo"},
-        {"id": "rms_04", "nombre": "Jersey Cuello Alto Hilo Trenzado Lino", "asset": "/assets/hermes_knit.png", "planta": "Planta 1 - Córner Lujo"},
-        {"id": "rms_05", "nombre": "Pantalón Recto de Lana de Sastrería", "asset": "/assets/hermes_pants.png", "planta": "Planta 1 - Córner Lujo"}
-    ]
+        {
+            "id": "rms_01",
+            "nombre": "Capa Corta en Cachemira Bone Hermès",
+            "asset": "/assets/hermes_cape.png",
+            "planta": "Planta 1 - Córner Lujo",
+        },
+        {
+            "id": "rms_02",
+            "nombre": "Pañuelo de Seda Estampado Art Deco",
+            "asset": "/assets/hermes_scarf.png",
+            "planta": "Planta 1 - Córner Lujo",
+        },
+        {
+            "id": "rms_03",
+            "nombre": "Chaqueta de Piel Flexible Suave Ecuestre",
+            "asset": "/assets/hermes_leather.png",
+            "planta": "Planta 1 - Córner Lujo",
+        },
+        {
+            "id": "rms_04",
+            "nombre": "Jersey Cuello Alto Hilo Trenzado Lino",
+            "asset": "/assets/hermes_knit.png",
+            "planta": "Planta 1 - Córner Lujo",
+        },
+        {
+            "id": "rms_05",
+            "nombre": "Pantalón Recto de Lana de Sastrería",
+            "asset": "/assets/hermes_pants.png",
+            "planta": "Planta 1 - Córner Lujo",
+        },
+    ],
 }
+
 
 @app.get("/status")
 async def get_status():
     return {"status": "online", "engine": "OMEGA_V10.2", "mode": "Empire"}
 
+
 @app.post("/api/lafayette/carrito")
 async def añadir_al_carrito(prenda: PrendaSeleccionada):
-    return {"status": "success", "tienda": "Galeries Lafayette Haussmann", "talla_asegurada": prenda.talla_calculada, "filtro": "Zero-Size Active"}
+    return {
+        "status": "success",
+        "tienda": "Galeries Lafayette Haussmann",
+        "talla_asegurada": prenda.talla_calculada,
+        "filtro": "Zero-Size Active",
+    }
+
 
 @app.get("/api/lafayette/reservar/{garment_id}")
 async def reservar_en_probador(garment_id: str):
@@ -96,6 +196,7 @@ async def reservar_en_probador(garment_id: str):
     img.save(buffer, format="PNG")
     return Response(content=buffer.getvalue(), media_type="image/png")
 
+
 @app.get("/api/lafayette/coleccion/{marca}")
 async def obtener_coleccion(marca: str):
     marca_key = marca.lower().strip()
@@ -103,18 +204,29 @@ async def obtener_coleccion(marca: str):
         raise HTTPException(status_code=404, detail="Firma no disponible")
     return {"marca": marca, "sugerencias": CATALOGO_GLOBAL[marca_key]}
 
+
 @app.post("/api/lafayette/silueta/guardar")
 async def guardar_silueta(data: DatosSilueta):
-    return {"status": "stored", "cliente_referencia": f"LAFAYETTE_USER_{str(uuid.uuid4())[:6].upper()}"}
+    return {
+        "status": "stored",
+        "cliente_referencia": f"LAFAYETTE_USER_{str(uuid.uuid4())[:6].upper()}",
+    }
+
 
 @app.post("/api/lafayette/metricas")
 async def registrar_metricas(metricas: dict):
     print(f"[Métricas] Log guardado: {metricas}")
     return {"status": "recorded"}
 
+
 @app.post("/api/lafayette/vip/activar")
 async def activar_vip(perfil: PerfilVIP):
-    return {"status": "EMPIRE_MODE_ACTIVE", "experiencia": "VIP Premium - Efecto Paloma", "probador_privado": "Reservado automáticamente - Salón Haussmann"}
+    return {
+        "status": "EMPIRE_MODE_ACTIVE",
+        "experiencia": "VIP Premium - Efecto Paloma",
+        "probador_privado": "Reservado automáticamente - Salón Haussmann",
+    }
+
 
 @app.post("/api/lafayette/vip/registrar-museum")
 async def registrar_museum(invitado: RegistroInvitadoVIP):
@@ -132,9 +244,18 @@ async def registrar_museum(invitado: RegistroInvitadoVIP):
     fecha_actual = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     with open(ARCHIVO_INVITADOS_MUSEUM, "a", newline="", encoding="utf-8") as f:
         writer = csv.writer(f)
-        writer.writerow([fecha_actual, invitado.email, invitado.origen, "Pendiente de Envío Entrada"])
+        writer.writerow(
+            [
+                fecha_actual,
+                invitado.email,
+                invitado.origen,
+                "Pendiente de Envío Entrada",
+            ]
+        )
     return {"status": "success", "email": invitado.email}
+
 
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run("main:app", host="127.0.0.1", port=8000, reload=True)

--- a/tests/test_cors_security.py
+++ b/tests/test_cors_security.py
@@ -1,0 +1,66 @@
+import unittest
+import os
+from unittest.mock import patch
+import importlib
+from fastapi.testclient import TestClient
+
+class TestCORSSecurity(unittest.TestCase):
+    def test_allowed_origins(self):
+        import main
+        importlib.reload(main)
+        client = TestClient(main.app)
+
+        headers = {
+            "Origin": "https://tryonyou.app",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "X-Requested-With"
+        }
+        response = client.options("/api/lafayette/metricas", headers=headers)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("access-control-allow-origin", response.headers)
+        self.assertEqual(response.headers["access-control-allow-origin"], "https://tryonyou.app")
+
+    def test_disallowed_origin(self):
+        import main
+        importlib.reload(main)
+        client = TestClient(main.app)
+
+        headers = {
+            "Origin": "https://evil.com",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "X-Requested-With"
+        }
+        response = client.options("/api/lafayette/metricas", headers=headers)
+        # Should not allow evil.com
+        if "access-control-allow-origin" in response.headers:
+            self.assertNotEqual(response.headers["access-control-allow-origin"], "https://evil.com")
+
+    @patch.dict(os.environ, {"E50_CORS_ALLOW_ORIGIN": "https://custom.app,http://localhost:8080"}, clear=True)
+    def test_env_var_override(self):
+        import main
+        importlib.reload(main)
+        client = TestClient(main.app)
+
+        # Test custom allowed
+        headers = {
+            "Origin": "https://custom.app",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "X-Requested-With"
+        }
+        response = client.options("/api/lafayette/metricas", headers=headers)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("access-control-allow-origin", response.headers)
+        self.assertEqual(response.headers["access-control-allow-origin"], "https://custom.app")
+
+        # Test default is NOT allowed since we overrode it
+        headers_default = {
+            "Origin": "https://tryonyou.app",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "X-Requested-With"
+        }
+        response_default = client.options("/api/lafayette/metricas", headers=headers_default)
+        if "access-control-allow-origin" in response_default.headers:
+            self.assertNotEqual(response_default.headers["access-control-allow-origin"], "https://tryonyou.app")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was an overly permissive CORS configuration in `main.py`. The `allow_origins=["*"]` wildcard meant that any origin could make requests to the API.

⚠️ **Risk:** The potential impact if left unfixed was that malicious websites could make cross-origin requests on behalf of authenticated users (similar to CSRF), potentially leaking sensitive data or performing unauthorized actions.

🛡️ **Solution:** The fix replaces the wildcard with a dynamically parsed list of allowed origins from the `E50_CORS_ALLOW_ORIGIN` environment variable. If the variable is not set, it safely falls back to explicitly allowed domains (`https://tryonyou.app` and `http://localhost:5173`). We also added comprehensive tests in `tests/test_cors_security.py` to assert this behavior.

---
*PR created automatically by Jules for task [16792119778750096383](https://jules.google.com/task/16792119778750096383) started by @LVT-ENG*