### PR TITLE
🧪 Add tests for _on function in asalto_final.py

### DIFF
--- a/tests/test_asalto_final.py
+++ b/tests/test_asalto_final.py
@@ -1,0 +1,25 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from asalto_final import _on
+
+class TestAsaltoFinal(unittest.TestCase):
+    def test_on_truthy_values(self):
+        truthy_values = ["1", "true", "yes", "on", " 1 ", " TRUE ", "YeS"]
+        for val in truthy_values:
+            with patch.dict(os.environ, {"TEST_VAR": val}, clear=True):
+                self.assertTrue(_on("TEST_VAR"), f"Expected True for value: '{val}'")
+
+    def test_on_falsy_values(self):
+        falsy_values = ["0", "false", "no", "off", " random ", ""]
+        for val in falsy_values:
+            with patch.dict(os.environ, {"TEST_VAR": val}, clear=True):
+                self.assertFalse(_on("TEST_VAR"), f"Expected False for value: '{val}'")
+
+    def test_on_unset_value(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertFalse(_on("UNSET_VAR"), "Expected False when env var is unset")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** Added tests for the `_on` function in `asalto_final.py` which checks if an environment variable represents a truthy state.\n📊 **Coverage:** Covered truthy values ('1', 'true', 'yes', 'on'), strings with spaces, falsy values, and unset environment variables using `unittest.mock.patch.dict`.\n✨ **Result:** Improved test coverage and reliability for environment variable parsing.

---
*PR created automatically by Jules for task [13755494919211479231](https://jules.google.com/task/13755494919211479231) started by @LVT-ENG*